### PR TITLE
Changing to find_packages in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
-from distutils.core import setup
+from setuptools import setup, find_packages
+
 
 setup(name='kernel_crawler',
       version='1.0.0',
@@ -8,7 +9,7 @@ setup(name='kernel_crawler',
       author='Grzegorz Nosek',
       author_email='grzegorz.nosek@sysdig.com',
       url='https://falco.org/',
-      packages=['kernel_crawler'],
+      packages=find_packages(),
       install_requires=[
           'click',
           'requests',


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**Any specific area of the project related to this PR?**
/area crawler

**What this PR does / why we need it**:
This PR enables other projects to actually import the kernel_crawler package. When attempting to import it after running `pip install git+https://github.com/falcosecurity/kernel-crawler.git` I would receive:
```
ModuleNotFoundError: No module named 'kernel_crawler.utils'
```

upon attempting to import the package. This was because the submodule, `utils` wasn't being properly bundled in setup.

**Which issue(s) this PR fixes**:
I can now import and use kernel-crawler in another project because with `find_packages()` it properly bundles the submodule `utils`

