### PR TITLE
fix(crawler): debian needs kbuild too in its headers output.

### DIFF
--- a/kernel_crawler/debian.py
+++ b/kernel_crawler/debian.py
@@ -46,4 +46,6 @@ class DebianMirror(repo.Distro):
         for dep in deps:
             if dep.find("headers") != -1:
                 headers.append(dep)
+            if dep.find("kbuild") != -1:
+                headers.append(dep)
         return repo.DriverKitConfig(release + "-" + self.arch, "debian", headers)


### PR DESCRIPTION
Signed-off-by: Federico Di Pierro <nierro92@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note: it's really useful for the changelog!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind documentation

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area crawler

> /area ci

> /area utils

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

It seems like debian needs linux-kbuild package too, to be able to correctly build on driverkit.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

