### PR TITLE
switching to vault.centos.org and adding archive.kernel.org

### DIFF
--- a/kernel_crawler/centos.py
+++ b/kernel_crawler/centos.py
@@ -19,9 +19,12 @@ class CentosMirror(repo.Distro):
             rpm.RpmMirror('http://mirror.centos.org/centos/', 'updates/' + arch + '/', v7_only),
             # CentOS 8 reached end-of-life at the end of 2021, so no point looking for it
             # rpm.RpmMirror('http://mirror.centos.org/centos/', 'BaseOS/' + arch + '/os/', v8_only),
-            rpm.RpmMirror('http://linuxsoft.cern.ch/centos-vault/', 'os/' + arch + '/', v6_or_v7),
-            rpm.RpmMirror('http://linuxsoft.cern.ch/centos-vault/', 'updates/' + arch + '/', v6_or_v7),
-            rpm.RpmMirror('http://linuxsoft.cern.ch/centos-vault/', 'BaseOS/' + arch + '/os/', v8_only),
+            rpm.RpmMirror('http://vault.centos.org/centos/', 'os/' + arch + '/', v6_or_v7),
+            rpm.RpmMirror('http://vault.centos.org/centos/', 'updates/' + arch + '/', v6_or_v7),
+            rpm.RpmMirror('http://vault.centos.org/centos/', 'BaseOS/' + arch + '/os/', v8_only),
+            rpm.RpmMirror('http://archive.kernel.org/centos/', 'os/' + arch + '/', v6_or_v7),
+            rpm.RpmMirror('http://archive.kernel.org/centos/', 'updates/' + arch + '/', v6_or_v7),
+            rpm.RpmMirror('http://archive.kernel.org/centos/', 'BaseOS/' + arch + '/os/', v8_only),
         ]
         super(CentosMirror, self).__init__(mirrors, arch)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+lxml
+click


### PR DESCRIPTION
Signed-off-by: Logan Bond <lbond@secureworks.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note: it's really useful for the changelog!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind documentation

/kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area crawler

> /area ci

> /area utils

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:
Swapping the mirrors for CentOS out for ones not hosted in China. We've implemented kernel crawler in our internal infra for use with Driverkit, but we have network policies in place to block China-hosted URLs. I swapped out the linuxsoft.cern.cn mirror for archive.kernel.org and vault.centos.org.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #25 

**Special notes for your reviewer**:

I added both archive.kernels.org and vault.centos.org to the mirror list. I do not think it should duplicate any URLs for a specific kernel header... At least, in my testing, it did not.
