### PR TITLE
fix(kernel_crawler): fixed ubuntu targets: actually use real ubuntu flavor as target

### DIFF
--- a/kernel_crawler/ubuntu.py
+++ b/kernel_crawler/ubuntu.py
@@ -29,7 +29,7 @@ class UbuntuMirror(repo.Distro):
                 if flavor_capture is not None:
                     flavor = flavor_capture.group(1)  # set flavor to the first capture group
 
-                target = 'ubuntu'  # driverkit just uses 'ubuntu'
+                target = f'ubuntu-{flavor}'    # expose the correct ubuntu flavor
                 release = f'{krel}-{flavor}'  # add flavor to release
 
                 val = dk_configs.get(target)


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

/kind cleanup

> /kind documentation

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area crawler

> /area ci

> /area utils

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR is part of a wider effort to support any ubuntu flavor to build Falco drivers; see:
* https://github.com/falcosecurity/driverkit/pull/201
* https://github.com/falcosecurity/falco/pull/2178

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

Note that kernel-crawler output wants to be as agnostic as possible from driverkit/test-infra
internal representation/implementation.
Therefore, we should adhere to correct ubuntu flavor as a target.
It is up to the consumers to fix data for their usage.