### PR TITLE
fix(kernel_crawler): fixed photonOS driverkit output ID.

### DIFF
--- a/kernel_crawler/__init__.py
+++ b/kernel_crawler/__init__.py
@@ -3,7 +3,7 @@ from .amazonlinux import AmazonLinux1Mirror, AmazonLinux2Mirror, AmazonLinux2022
 from .centos import CentosMirror
 from .fedora import FedoraMirror
 from .oracle import Oracle6Mirror, Oracle7Mirror, Oracle8Mirror
-from .photon_os import PhotonOsMirror
+from .photon import PhotonOsMirror
 
 from .debian import DebianMirror
 from .ubuntu import UbuntuMirror

--- a/kernel_crawler/photon.py
+++ b/kernel_crawler/photon.py
@@ -28,4 +28,4 @@ class PhotonOsMirror(repo.Distro):
     def to_driverkit_config(self, release, deps):
         for dep in deps:
             if dep.find("linux-devel") != -1:
-                return repo.DriverKitConfig(release, "photonOS", dep)
+                return repo.DriverKitConfig(release, "photon", dep)


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area crawler

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

OS_ID in /etc/os-release for photonOS is actually "photon".
```
NAME="VMware Photon OS"
VERSION="4.0"
ID=photon
VERSION_ID=4.0
PRETTY_NAME="VMware Photon OS/Linux"
ANSI_COLOR="1;34"
HOME_URL="https://vmware.github.io/photon/"
BUG_REPORT_URL="https://github.com/vmware/photon/issues"
```

**Which issue(s) this PR fixes**:

Allows photonOS driver build (driverkit uses the right `photon` target).

Fixes #

**Special notes for your reviewer**:

