### PR TITLE
fix(kernel_crawler): make flatcar distro support similar to minikube

### DIFF
--- a/kernel_crawler/flatcar.py
+++ b/kernel_crawler/flatcar.py
@@ -1,4 +1,5 @@
 import os
+import base64
 
 import requests
 from lxml import html
@@ -15,8 +16,9 @@ class FlatcarRepository(Repository):
         release = os.path.basename(self.base_url.rstrip('/'))
         if version not in release:
             return {}
-        dev_container = os.path.join(self.base_url, 'flatcar_developer_container.bin.bz2')
-        return {release: [dev_container]}
+        defconfig = os.path.join(self.base_url, 'flatcar_production_image_kernel_config.txt')
+        defconfig_base64 = base64.b64encode(requests.get(defconfig).content).decode()
+        return {release: [defconfig_base64]}
 
     def __str__(self):
         return self.base_url
@@ -50,4 +52,4 @@ class FlatcarMirror(Distro):
         return repos
 
     def to_driverkit_config(self, release, deps):
-        return repo.DriverKitConfig(release, "flatcar", list(deps))
+        return repo.DriverKitConfig(release, "flatcar", None, 1, list(deps)[0])


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area crawler

**What this PR does / why we need it**:

Instead of storing an useless URL (that downloaded 900M worth of data in driverkit, and then driverkit was not able to use it), directly store kernelconfigdata, just like we do for minikube.

**Which issue(s) this PR fixes**:

Together with a PR on driverkit (https://github.com/falcosecurity/driverkit/pull/215), this allows building drivers for flatcar.
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

