### PR TITLE
Adding 5.15 to AmazonLinux2 kernel urls

### DIFF
--- a/kernel_crawler/amazonlinux.py
+++ b/kernel_crawler/amazonlinux.py
@@ -70,7 +70,6 @@ class AmazonLinux2Mirror(repo.Distro):
             if dep.find("devel") != -1:
                 return repo.DriverKitConfig(release, "amazonlinux2", dep)
 
-
 class AmazonLinux2022Mirror(repo.Distro):
     # This was obtained by running
     # docker run -it --rm amazonlinux:2022 python3 -c 'import dnf, json; db = dnf.dnf.Base(); print(json.dumps(db.conf.substitutions, indent=2))'
@@ -97,3 +96,4 @@ class AmazonLinux2022Mirror(repo.Distro):
         for dep in deps:
             if dep.find("devel") != -1:
                 return repo.DriverKitConfig(release, "amazonlinux2022", dep)
+

--- a/kernel_crawler/amazonlinux.py
+++ b/kernel_crawler/amazonlinux.py
@@ -51,6 +51,7 @@ class AmazonLinux2Mirror(repo.Distro):
         'core/latest',
         'extras/kernel-5.4/latest',
         'extras/kernel-5.10/latest',
+        'extras/kernel-5.15/latest',
     ]
 
     def __init__(self, arch):

--- a/kernel_crawler/amazonlinux.py
+++ b/kernel_crawler/amazonlinux.py
@@ -70,6 +70,7 @@ class AmazonLinux2Mirror(repo.Distro):
             if dep.find("devel") != -1:
                 return repo.DriverKitConfig(release, "amazonlinux2", dep)
 
+
 class AmazonLinux2022Mirror(repo.Distro):
     # This was obtained by running
     # docker run -it --rm amazonlinux:2022 python3 -c 'import dnf, json; db = dnf.dnf.Base(); print(json.dumps(db.conf.substitutions, indent=2))'


### PR DESCRIPTION
Signed-off-by: Logan Bond <lbond@secureworks.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note: it's really useful for the changelog!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind documentation

/kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area crawler

> /area ci

> /area utils

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:
This PR adds support for new AmazonLinux2 5.15.x kernels, which are stored under a different path name. We had an instance today of a customer running one of these new kernels that kernel-crawler was unable to find. In a local test, adding the path to the repo list was the simple fix 😄 

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

