### PR TITLE
Adding initial support for OpenSUSE

### DIFF
--- a/kernel_crawler/crawler.py
+++ b/kernel_crawler/crawler.py
@@ -8,6 +8,8 @@ from .oracle import Oracle6Mirror, Oracle7Mirror, Oracle8Mirror
 from .photon import PhotonOsMirror
 from .rockylinux import RockyLinuxMirror
 
+from .opensuse import OpenSUSEMirror
+
 from .debian import DebianMirror
 from .ubuntu import UbuntuMirror
 
@@ -27,6 +29,8 @@ DISTROS = {
     'Oracle8': Oracle8Mirror,
     'PhotonOS': PhotonOsMirror,
     'RockyLinux': RockyLinuxMirror,
+
+    'OpenSUSE': OpenSUSEMirror,
 
     'Debian': DebianMirror,
     'Ubuntu': UbuntuMirror,

--- a/kernel_crawler/opensuse.py
+++ b/kernel_crawler/opensuse.py
@@ -1,13 +1,6 @@
 from . import repo
 from . import rpm
 
-from lxml import etree, html
-from bs4 import BeautifulSoup
-from kernel_crawler.utils.download import get_url
-
-import requests
-import sys
-
 def opensuse_filter(dist):
     return dist.startswith('openSUSE') or \
         dist.startswith('./openSUSE')  or \

--- a/kernel_crawler/opensuse.py
+++ b/kernel_crawler/opensuse.py
@@ -9,19 +9,17 @@ import requests
 import sys
 
 def opensuse_filter(dist):
-    return not dist.startswith('linux-next') \
-    and (
-        dist.startswith('openSUSE')   or
-        dist.startswith('./openSUSE') or
-        dist.startswith('HEAD')       or
+    return dist.startswith('openSUSE') or \
+        dist.startswith('./openSUSE')  or \
+        dist.startswith('HEAD')        or \
         dist.startswith('stable')
-    )
 
 def tumbleweed_filter(dist):
     return dist.startswith('tumbleweed')
 
 
 class OpenSUSEMirror(repo.Distro):
+
 
     def __init__(self, arch):
         mirrors = [
@@ -48,7 +46,23 @@ class OpenSUSEMirror(repo.Distro):
 
         super(OpenSUSEMirror, self).__init__(mirrors, arch)
 
+
     def to_driverkit_config(self, release, deps):
+
+        # matches driverkit target cli option
+        target = 'opensuse'
+
+        # dict for storing list of 
+        dk_configs = {}
+
+        # loop over deps for a given release and append
         for dep in deps:
-            if dep.find("devel") != -1:
-                return repo.DriverKitConfig(release, "opensuse", dep)
+            val = dk_configs.get(target)
+            if not val:
+                headers = [dep]
+                dk_configs[target] = repo.DriverKitConfig(release, target, headers)
+            else:
+                val.headers.append(dep)
+                dk_configs[target] = val
+
+        return dk_configs.values()

--- a/kernel_crawler/opensuse.py
+++ b/kernel_crawler/opensuse.py
@@ -1,0 +1,29 @@
+from . import repo
+from . import rpm
+
+from lxml import etree, html
+from bs4 import BeautifulSoup
+from kernel_crawler.utils.download import get_url
+
+import requests
+import sys
+
+
+class OpenSUSEMirror(repo.Distro):
+
+    def __init__(self, arch):
+        mirrors = [
+            # leap
+            rpm.SUSERpmMirror('https://mirrors.edge.kernel.org/opensuse/distribution/leap/', 'repo/oss/', arch),
+            rpm.SUSERpmMirror('https://mirrors.edge.kernel.org/opensuse/distribution/leap/', 'repo/oss/suse/', arch),
+            # the rest
+            rpm.SUSERpmMirror('https://mirrors.edge.kernel.org/opensuse/distribution/', 'repo/oss/', arch),
+            rpm.SUSERpmMirror('https://mirrors.edge.kernel.org/opensuse/distribution/', 'repo/oss/suse/', arch),
+        ]
+
+        super(OpenSUSEMirror, self).__init__(mirrors, arch)
+
+    def to_driverkit_config(self, release, deps):
+        for dep in deps:
+            if dep.find("devel") != -1:
+                return repo.DriverKitConfig(release, "opensuse", dep)

--- a/kernel_crawler/opensuse.py
+++ b/kernel_crawler/opensuse.py
@@ -8,6 +8,18 @@ from kernel_crawler.utils.download import get_url
 import requests
 import sys
 
+def opensuse_filter(dist):
+    return not dist.startswith('linux-next') \
+    and (
+        dist.startswith('openSUSE')   or
+        dist.startswith('./openSUSE') or
+        dist.startswith('HEAD')       or
+        dist.startswith('stable')
+    )
+
+def tumbleweed_filter(dist):
+    return dist.startswith('tumbleweed')
+
 
 class OpenSUSEMirror(repo.Distro):
 
@@ -19,7 +31,20 @@ class OpenSUSEMirror(repo.Distro):
             # the rest
             rpm.SUSERpmMirror('https://mirrors.edge.kernel.org/opensuse/distribution/', 'repo/oss/', arch),
             rpm.SUSERpmMirror('https://mirrors.edge.kernel.org/opensuse/distribution/', 'repo/oss/suse/', arch),
+            # opensuse site: tumbleweed
+            rpm.SUSERpmMirror('http://download.opensuse.org/', 'repo/oss/', arch, tumbleweed_filter),
+            # opensuse site: leaps
+            rpm.SUSERpmMirror('http://download.opensuse.org/distribution/leap/', 'repo/oss/', arch),
         ]
+
+        # other arch's are stored differently on SUSE's site
+        # in general, the /repositories/Kernel:/ are stored differently and require a filter
+        if arch == 'x86_64':
+            mirrors.append(rpm.SUSERpmMirror('https://download.opensuse.org/repositories/Kernel:/', 'Submit/standard/', arch, opensuse_filter))
+            mirrors.append(rpm.SUSERpmMirror('https://download.opensuse.org/repositories/Kernel:/', 'standard/', arch, opensuse_filter))
+        else:
+            mirrors.append(rpm.SUSERpmMirror('https://download.opensuse.org/repositories/Kernel:/', 'Submit/ports/', arch, opensuse_filter))
+            mirrors.append(rpm.SUSERpmMirror('https://download.opensuse.org/repositories/Kernel:/', 'ports/', arch, opensuse_filter))
 
         super(OpenSUSEMirror, self).__init__(mirrors, arch)
 

--- a/kernel_crawler/rpm.py
+++ b/kernel_crawler/rpm.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 from __future__ import print_function
-from asyncio import base_tasks
 import traceback
 
 import requests


### PR DESCRIPTION
Signed-off-by: Logan Bond <lbond@secureworks.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note: it's really useful for the changelog!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind documentation

/kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area crawler

> /area ci

> /area utils

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:
Adds initial support for OpenSUSE 🙂

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
OpenSUSE is an RPM based distro, but stores their repo metadata quite differently from the others. Where the other RPM distros store their package information in a SQLite DB, SUSE just keeps is real with XML 🤦 So I had to create specific `SUSERpmMirror` and `SUSERpmRepository` classes that are extensions of the normal `RpmMirror` and `RpmRepository` classes with overriden methods where necessary.

Also, in the repo metadata, SUSE appears to keep only the _current_ or _latest_ `kernel-debug-devel` (they are not just named `kernel-devel`) package available for whatever reason. If anyone knows of a better place where more are listed than just latest, that would be fantastic, but I couldn't find anywhere... Even the download.opensuse.org site only shows latest.

Otherwise, crawling OpenSUSE looks mostly like crawling for CentOS or Rocky - get the `repomd.xml`, parse it to find the `primary` package listing, then open that and search for `kernel-debug-devel`.

Example driverkit formatted output:
```
╰─❯ kernel-crawler crawl --distro OpenSUSE --out_fmt driverkit
Checking repositories  [####################################]  100%                                                                       
Listing packages  [####################################]  100%                                                                                                
{
  "OpenSUSE": [
    {
      "kernelversion": 1,
      "kernelrelease": "5.3.18-lp152.19.2.x86_64",
      "target": "opensuse",
      "headers": [
        "https://mirrors.edge.kernel.org/opensuse/distribution/leap/15.2/repo/oss/x86_64/kernel-debug-devel-5.3.18-lp152.19.2.x86_64.rpm"
      ]
    },
    {
      "kernelversion": 1,
      "kernelrelease": "5.3.18-57.3.x86_64",
      "target": "opensuse",
      "headers": [
        "http://download.opensuse.org/distribution/leap/15.3/repo/oss/x86_64/kernel-debug-devel-5.3.18-57.3.x86_64.rpm"
      ]
    },
    {
      "kernelversion": 1,
      "kernelrelease": "5.14.21-150400.22.1.x86_64",
      "target": "opensuse",
      "headers": [
        "https://mirrors.edge.kernel.org/opensuse/distribution/leap/15.4/repo/oss/x86_64/kernel-debug-devel-5.14.21-150400.22.1.x86_64.rpm"
      ]
    },
    {
      "kernelversion": 1,
      "kernelrelease": "5.14.21-150500.30.2.x86_64",
      "target": "opensuse",
      "headers": [
        "https://mirrors.edge.kernel.org/opensuse/distribution/leap/15.5/repo/oss/x86_64/kernel-debug-devel-5.14.21-150500.30.2.x86_64.rpm"
      ]
    },
    {
      "kernelversion": 1,
      "kernelrelease": "4.4.76-1.1.x86_64",
      "target": "opensuse",
      "headers": [
        "https://mirrors.edge.kernel.org/opensuse/distribution/leap/42.3/repo/oss/suse/x86_64/kernel-debug-devel-4.4.76-1.1.x86_64.rpm"
      ]
    },
    {
      "kernelversion": 1,
      "kernelrelease": "6.0.3-1.1.x86_64",
      "target": "opensuse",
      "headers": [
        "http://download.opensuse.org/tumbleweed/repo/oss/x86_64/kernel-debug-devel-6.0.3-1.1.x86_64.rpm"
      ]
    },
    {
      "kernelversion": 1,
      "kernelrelease": "4.12.14-lp150.11.4.x86_64",
      "target": "opensuse",
      "headers": [
        "http://download.opensuse.org/distribution/leap/15.0/repo/oss/x86_64/kernel-debug-devel-4.12.14-lp150.11.4.x86_64.rpm"
      ]
    },
    {
      "kernelversion": 1,
      "kernelrelease": "4.12.14-lp151.27.3.x86_64",
      "target": "opensuse",
      "headers": [
        "http://download.opensuse.org/distribution/leap/15.1/repo/oss/x86_64/kernel-debug-devel-4.12.14-lp151.27.3.x86_64.rpm"
      ]
    },
    {
      "kernelversion": 1,
      "kernelrelease": "4.12.14-lp150.42.1.g64c1ef2.x86_64",
      "target": "opensuse",
      "headers": [
        "https://download.opensuse.org/repositories/Kernel:/./openSUSE-15.0:/Submit/standard/x86_64/kernel-debug-devel-4.12.14-lp150.42.1.g64c1ef2.x86_64.rpm"
      ]
    },
    {
      "kernelversion": 1,
      "kernelrelease": "4.12.14-lp151.48.1.ge284d31.x86_64",
      "target": "opensuse",
      "headers": [
        "https://download.opensuse.org/repositories/Kernel:/./openSUSE-15.1:/Submit/standard/x86_64/kernel-debug-devel-4.12.14-lp151.48.1.ge284d31.x86_64.rpm"
      ]
    },
    {
      "kernelversion": 1,
      "kernelrelease": "4.4.180-1.1.g7cfa20a.x86_64",
      "target": "opensuse",
      "headers": [
        "https://download.opensuse.org/repositories/Kernel:/./openSUSE-42.3:/Submit/standard/x86_64/kernel-debug-devel-4.4.180-1.1.g7cfa20a.x86_64.rpm"
      ]
    },
    {
      "kernelversion": 1,
      "kernelrelease": "6.1~rc2-2.1.g6516615.x86_64",
      "target": "opensuse",
      "headers": [
        "https://download.opensuse.org/repositories/Kernel:/HEAD/standard/x86_64/kernel-debug-devel-6.1~rc2-2.1.g6516615.x86_64.rpm"
      ]
    },
    {
      "kernelversion": 1,
      "kernelrelease": "5.3.18-lp152.289.1.g67cecba.x86_64",
      "target": "opensuse",
      "headers": [
        "https://download.opensuse.org/repositories/Kernel:/openSUSE-15.2/standard/x86_64/kernel-debug-devel-5.3.18-lp152.289.1.g67cecba.x86_64.rpm"
      ]
    },
    {
      "kernelversion": 1,
      "kernelrelease": "6.0.5-3.1.g7359656.x86_64",
      "target": "opensuse",
      "headers": [
        "https://download.opensuse.org/repositories/Kernel:/stable/standard/x86_64/kernel-debug-devel-6.0.5-3.1.g7359656.x86_64.rpm"
      ]
    }
  ]
}
```

