### PR TITLE
Add initial ArchLinux support

### DIFF
--- a/kernel_crawler/archlinux.py
+++ b/kernel_crawler/archlinux.py
@@ -54,8 +54,9 @@ class ArchLinuxMirror(repo.Distro):
             self._base_urls.append('https://archive.archlinux.org/packages/l/linux-hardened-headers/')        # hardened
             self._base_urls.append('https://archive.archlinux.org/packages/l/linux-lts-headers/')             # lts
             self._base_urls.append('https://archive.archlinux.org/packages/l/linux-zen-headers/')             # zen
-        else:
+        elif arch == 'aarch64':
             self._base_urls.append('http://tardis.tiny-vps.com/aarm/packages/l/linux-aarch64-headers/')       # arm 64-bit
+        else:  # can be implemented later
             self._base_urls.append('http://tardis.tiny-vps.com/aarm/packages/l/linux-armv5-headers/')         # arm v5
             self._base_urls.append('http://tardis.tiny-vps.com/aarm/packages/l/linux-armv7-headers/')         # arm v7
             self._base_urls.append('http://tardis.tiny-vps.com/aarm/packages/l/linux-raspberrypi4-headers/')  # rpi4

--- a/kernel_crawler/archlinux.py
+++ b/kernel_crawler/archlinux.py
@@ -1,0 +1,64 @@
+from bs4 import BeautifulSoup
+import re
+
+from kernel_crawler.utils.download import get_url
+from . import repo
+
+class ArchLinuxRepository(repo.Repository):
+
+    _linux_headers_pattern = 'linux.*headers-'
+    _package_suffix_pattern = '.pkg.tar.*'
+
+    def __init__(self, base_url):
+        self.base_url = base_url
+
+    def __str__(self):
+        return self.base_url
+
+    def parse_kernel_release(self, kernel_package):
+
+        trimmed = re.sub(self._linux_headers_pattern, '', kernel_package)
+        version = re.sub(self._package_suffix_pattern, '', trimmed)
+
+        return version
+
+    def get_package_tree(self, filter=''):
+        packages = {}
+
+        soup = BeautifulSoup(get_url(self.base_url), features='lxml')
+        for a in soup.find_all('a', href=True):
+            package = a['href']
+            # skip .sig and .. links
+            if not package.endswith('.sig') and package != '../':
+                parsed_kernel_release = self.parse_kernel_release(package)
+
+                packages.setdefault(parsed_kernel_release, set()).add(self.base_url + package)
+
+        return packages
+
+
+class ArchLinuxMirror(repo.Distro):
+
+    _base_urls = [
+        'https://archive.archlinux.org/packages/l/linux-headers/',           # stable
+        'https://archive.archlinux.org/packages/l/linux-hardened-headers/',  # hardened
+        'https://archive.archlinux.org/packages/l/linux-lts-headers/',       # lts
+        'https://archive.archlinux.org/packages/l/linux-zen-headers/',       # zen
+    ]
+
+    def __init__(self, arch):
+        super(ArchLinuxMirror, self).__init__(self._base_urls, arch)
+
+
+    def list_repos(self):
+        mirrors = []
+
+        for mirror in self._base_urls:
+            mirrors.append(ArchLinuxRepository(mirror))
+
+        return mirrors
+
+
+    def to_driverkit_config(self, release, deps):
+        for dep in deps:
+            return repo.DriverKitConfig(release, "arch", dep)

--- a/kernel_crawler/crawler.py
+++ b/kernel_crawler/crawler.py
@@ -17,6 +17,8 @@ from .flatcar import FlatcarMirror
 
 from .redhat import RedhatContainer
 
+from .archlinux import ArchLinuxMirror
+
 DISTROS = {
     'AlmaLinux': AlmaLinuxMirror,
     'AmazonLinux': AmazonLinux1Mirror,
@@ -39,7 +41,9 @@ DISTROS = {
     
     'Minikube': MinikubeMirror,
 
-    'Redhat': RedhatContainer
+    'Redhat': RedhatContainer,
+
+    'ArchLinux': ArchLinuxMirror,
 }
 
 def to_driverkit_config(d, res):


### PR DESCRIPTION
Signed-off-by: Logan Bond <lbond@secureworks.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note: it's really useful for the changelog!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind documentation

/kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area crawler

> /area ci

> /area utils

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:
Adds initial support for crawling ArchLinux

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes # N/A

**Special notes for your reviewer**:

ArchLinux puts out 4 kernel types:
1. stable
2. hardened
3. lts
4. zen

Each of those can be found under: https://archive.archlinux.org/packages/l/ - however, only in `x86_64`. I may be missing something, but I'm unsure where to find other architectures. `x86_64` should get us a good initial support group.

Also, I think `driverkit` may need to update to handle Arch a little differently..? Here's some sample output I've generated with this PR:
```
    {
      "kernelversion": 1,
      "kernelrelease": "6.0.zen1-1-x86_64",
      "target": "arch",
      "headers": [
        "https://archive.archlinux.org/packages/l/linux-zen-headers/linux-zen-headers-6.0.zen1-1-x86_64.pkg.tar.zst"
      ]
    }
```
However, I can't figure out exactly what driverkit wants the user to input for ArchLinux. My preference would be to update driverkit to match this PR - where the kernel type (one of the 4 above) is part of the kernel release string, along with the architecture type. This proposed format would look similar to CentOS or Rocky where the `kernelrelease` field maintains the architecture and is the full `uname` output. Example from Rocky to compare:
```
    {
      "kernelversion": 1,
      "kernelrelease": "5.14.0-70.26.1.el9_0.x86_64",
      "target": "rocky",
      "headers": [
        "http://dl.rockylinux.org/pub/rocky/9.0/AppStream/x86_64/os/Packages/k/kernel-devel-5.14.0-70.26.1.el9_0.x86_64.rpm"
      ]
    }
```
^ full `kernelrelease`, including the architecture. If I were to update driverkit for ArchLinux, the kernel release regex would have to change though.

Let me know what you'd like to do though, I can make mods here if needed. Otherwise, there are so many Arch kernels since it's a rolling distro, it's hard to post a full output size. Here's a snippet though:
```
╰─❯ kernel-crawler crawl --distro ArchLinux --out_fmt driverkit | jq -r '.ArchLinux[] | .kernelrelease' | wc -l
Listing packages  [####################################]  100%                                                                       
1331
```