### PR TITLE
fix(minikube): print only once the progress bar label when not in tty

### DIFF
--- a/kernel_crawler/minikube.py
+++ b/kernel_crawler/minikube.py
@@ -15,13 +15,17 @@ from .repo import Distro, DriverKitConfig
 class ProgressCallback(pygit2.RemoteCallbacks):
     def __init__(self):
         self.progress_bar_initialized = False
+        self.bar = None
         super().__init__()
     def transfer_progress(self, stats):
         if not self.progress_bar_initialized:
-            bar = ProgressBar(label='Cloning minikube repository',length=stats.total_objects, file=sys.stderr)
-        bar.update(stats.indexed_objects)
+            self.bar = ProgressBar(label='Cloning minikube repository',length=stats.total_objects, file=sys.stderr)
+            self.bar.update(1)
+            self.progress_bar_initialized = True
+        if not self.bar.is_hidden:
+            self.bar.update(1, stats.indexed_objects)
         if stats.indexed_objects == stats.total_objects:
-            bar.render_finish()
+            self.bar.render_finish()
 
 class MinikubeMirror(Distro):
     # dictionary keys used to build the kernel configuration dict.
@@ -97,6 +101,8 @@ class MinikubeMirror(Distro):
 
     def get_package_tree(self, version=''):
         repo = self.list_repos()
+        print("the repo has been downloaded")
+        sys.stdout.flush()
         kernel_configs = {}
         minikube_versions = self.getVersions(repo)
         


### PR DESCRIPTION
Signed-off-by: Aldo Lacuku <aldo@lacuku.eu>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note: it's really useful for the changelog!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind documentation

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area crawler

> /area ci

> /area utils

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:
Print only once the progress bar label when not in tty.
**Which issue(s) this PR fixes**:
#65
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

