### PR TITLE
fix: avoid None object de-reference

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-slim-buster
+FROM python:3.10-slim
 
 WORKDIR /app
 

--- a/kernel_crawler/rpm.py
+++ b/kernel_crawler/rpm.py
@@ -243,7 +243,8 @@ class SUSERpmRepository(RpmRepository):
             # regex searching through a file is more memory efficient
             # than parsing the xml into an object structure with lxml etree
             search = re.search(f'.*href="({package_match}.*rpm)', str(open(tf.name).read()))
-            kernel_default_devel_pkg_url = search.group(1)
+            if search:
+                kernel_default_devel_pkg_url = search.group(1)
             tf.close()  # delete the tempfile to free up memory
 
         # check to ensure a kernel_devel_pkg was found


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area crawler
/area ci

**What this PR does / why we need it**:

Avoid a None object de-reference in rpm crawler; moreover, bump python docker image to 3.10.

**Which issue(s) this PR fixes**:

Hopefully fixes test-infra prow job :/ 
https://prow.falco.org/view/s3/falco-prow-logs/logs/update-kernels/1592034626627440640

Fixes #

**Special notes for your reviewer**:

