### PR TITLE
fix(kernel_crawler): proper exceptions handling in flatcar GET request.

### DIFF
--- a/kernel_crawler/flatcar.py
+++ b/kernel_crawler/flatcar.py
@@ -33,8 +33,11 @@ class FlatcarMirror(Distro):
         super(FlatcarMirror, self).__init__(mirrors, arch)
 
     def scan_repo(self, base_url):
-        dists = requests.get(base_url)
-        dists.raise_for_status()
+        try:
+            dists = requests.get(base_url)
+            dists.raise_for_status()
+        except requests.exceptions.RequestException:
+            return {}
         dists = dists.content
         doc = html.fromstring(dists, base_url)
         dists = doc.xpath('/html/body//a[not(@href="../")]/@href')


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area crawler

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

Avoid errors such as 
```
Traceback (most recent call last):
  File "/usr/local/bin/kernel-crawler", line 8, in <module>
    sys.exit(cli())
  File "/usr/local/lib/python3.10/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.10/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.10/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.10/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.10/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/usr/local/lib/python3.10/site-packages/kernel_crawler/main.py", line 56, in crawl
    res = crawl_kernels(distro, version, arch, image, out_fmt == 'driverkit')
  File "/usr/local/lib/python3.10/site-packages/kernel_crawler/crawler.py", line 89, in crawl_kernels
    res = d.get_package_tree(version)
  File "/usr/local/lib/python3.10/site-packages/kernel_crawler/repo.py", line 43, in get_package_tree
    repos = self.list_repos()
  File "/usr/local/lib/python3.10/site-packages/kernel_crawler/flatcar.py", line 51, in list_repos
    repos.extend(self.scan_repo(repo))
  File "/usr/local/lib/python3.10/site-packages/kernel_crawler/flatcar.py", line 36, in scan_repo
    dists = requests.get(base_url)
  File "/usr/local/lib/python3.10/site-packages/requests/api.py", line 73, in get
    return request("get", url, params=params, **kwargs)
  File "/usr/local/lib/python3.10/site-packages/requests/api.py", line 59, in request
    return session.request(method=method, url=url, **kwargs)
  File "/usr/local/lib/python3.10/site-packages/requests/sessions.py", line 587, in request
    resp = self.send(prep, **send_kwargs)
  File "/usr/local/lib/python3.10/site-packages/requests/sessions.py", line 701, in send
    r = adapter.send(request, **kwargs)
  File "/usr/local/lib/python3.10/site-packages/requests/adapters.py", line 565, in send
    raise ConnectionError(e, request=request)
requests.exceptions.ConnectionError: HTTPSConnectionPool(host='stable.release.flatcar-linux.net', port=443): Max retries exceeded with url: /amd64-usr/ (Caused by NewConnectionError('<urllib3.connection.HTTPSConnection object at 0x7f32b575c610>: Failed to establish a new connection: [Errno 111] Connection refused'))
```
when a flatcar repo cannot be reached.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

