### PR TITLE
new: add support for bottlerocket os

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
           
       - name: Run crawler
         run: |
-          kernel-crawler crawl --distro "*" --out_fmt driverkit > kernels.json
+          kernel-crawler crawl --distro "*" > kernels.json
           
       - name: Validate json
         run: |

--- a/README.md
+++ b/README.md
@@ -28,10 +28,9 @@ Crawl command:
 Usage: kernel-crawler crawl [OPTIONS]
 
 Options:
-    --distro [AmazonLinux|AmazonLinux2|AmazonLinux2022|CentOS|Debian|Fedora|Flatcar|Minikube|Oracle6|Oracle7|Oracle8|PhotonOS|Redhat|Ubuntu|*]
+    --distro [AmazonLinux|AmazonLinux2|AmazonLinux2022|BottleRocketCentOS|Debian|Fedora|Flatcar|Minikube|Oracle6|Oracle7|Oracle8|PhotonOS|Redhat|Ubuntu|*]
     --version TEXT
     --arch [x86_64|aarch64]
-    --out_fmt [plain|json|driverkit]
     --image TEXT                    Option is required when distro is Redhat.
     --help                          Show this message and exit.
 ```
@@ -51,19 +50,14 @@ To install the project, a simple `pip3 install .` from project root is enough.
 
 ## Examples
 
-* Crawl amazonlinux2 kernels, with no-formatted output:
+* Crawl amazonlinux2 kernels:
 ```commandline
 kernel-crawler crawl --distro=AmazonLinux2
 ```
 
-* Crawl ubuntu kernels, with [driverkit](https://github.com/falcosecurity/driverkit) config-like output:
+* Crawl all supported distros kernels:
 ```commandline
-kernel-crawler crawl --distro=Ubuntu --out_fmt=driverkit
-```
-
-* Crawl all supported distros kernels, with json output:
-```commandline
-kernel-crawler crawl --distro=* --out_fmt=json
+kernel-crawler crawl --distro=*
 ```
 | :exclamation: **Note**: Passing ```--image``` argument is supported with ```--distro=*``` |
 |-------------------------------------------------------------------------------------------|

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Crawl command:
 Usage: kernel-crawler crawl [OPTIONS]
 
 Options:
-    --distro [AmazonLinux|AmazonLinux2|AmazonLinux2022|BottleRocketCentOS|Debian|Fedora|Flatcar|Minikube|Oracle6|Oracle7|Oracle8|PhotonOS|Redhat|Ubuntu|*]
+    --distro [AmazonLinux|AmazonLinux2|AmazonLinux2022|BottleRocket|CentOS|Debian|Fedora|Flatcar|Minikube|Oracle6|Oracle7|Oracle8|PhotonOS|Redhat|Ubuntu|*]
     --version TEXT
     --arch [x86_64|aarch64]
     --image TEXT                    Option is required when distro is Redhat.

--- a/kernel_crawler/bottlerocket.py
+++ b/kernel_crawler/bottlerocket.py
@@ -19,19 +19,19 @@ class BottleRocketMirror(GitMirror):
         return "kernel-" + kver + ".spec"
 
     def get_package_tree(self, version=''):
-        repo = self.list_repos()
+        self.list_repo()
         sys.stdout.flush()
         kernel_configs = {}
-        bottlerocket_versions = self.getVersions(repo, 3)
+        bottlerocket_versions = self.getVersions(3)
 
         for v in bottlerocket_versions:
             bar = ProgressBar(label="Building config for bottlerocket v{}".format(v), length=1, file=sys.stderr)
-            self.checkout_version(v, repo)
+            self.checkout_version(v)
             # same meaning as the output of "uname -r"
             for kver in self.supported_kernel_releases:
-                kernel_release = self.extract_kernel_release(v, repo, self.get_bottlerocket_kernel_spec(kver))
+                kernel_release = self.extract_value(self.get_bottlerocket_kernel_spec(kver), "Version", ":")
                 kernel_version = "1_" + v
-                defconfig_base64 = self.encode_base64_defconfig(v, repo, self.get_kernel_config_file_name())
+                defconfig_base64 = self.encode_base64_defconfig(self.get_kernel_config_file_name())
                 kernel_configs[v + "_" + kver] = {
                     self.KERNEL_VERSION: kernel_version,
                     self.KERNEL_RELEASE: kernel_release,
@@ -41,5 +41,5 @@ class BottleRocketMirror(GitMirror):
             bar.update(1)
             bar.render_finish()
 
-        shutil.rmtree(repo.workdir, True)
+        self.cleanup_repo()
         return kernel_configs

--- a/kernel_crawler/bottlerocket.py
+++ b/kernel_crawler/bottlerocket.py
@@ -1,6 +1,9 @@
-import shutil
+import base64
+import os
 import sys
 
+import requests
+import rpmfile
 from click import progressbar as ProgressBar
 
 from .git import GitMirror
@@ -8,15 +11,61 @@ from .git import GitMirror
 
 class BottleRocketMirror(GitMirror):
     supported_kernel_releases = ["5.10", "5.15"]
+    supported_flavors = ["aws", "metal", "vmware"]
 
     def __init__(self, arch):
         super(BottleRocketMirror, self).__init__("bottlerocket-os", "bottlerocket", arch)
 
-    def get_kernel_config_file_name(self):
-        return "config-bottlerocket"
+    def get_kernel_config_file_name(self, flavor=''):
+        return "config-bottlerocket"+flavor
 
     def get_bottlerocket_kernel_spec(self, kver):
         return "kernel-" + kver + ".spec"
+
+    def fetch_base_config(self, kver):
+        source = self.extract_value(self.get_bottlerocket_kernel_spec(kver), "Source0", ":")
+        if source is None:
+            return None
+
+        alkernel = requests.get(source)
+        alkernel.raise_for_status()
+        with open('/tmp/alkernel.rpm', 'wb') as f:
+            f.write(alkernel.content)
+
+        with rpmfile.open('/tmp/alkernel.rpm') as rpm:
+            # Extract a fileobject from the archive
+            fd = rpm.extractfile('config-' + self.arch)
+            baseconfig = [line for line in fd.readlines()]
+
+        os.remove('/tmp/alkernel.rpm')
+        return baseconfig
+
+    def set_kernel_config(self, baseconfig, key, value):
+        for i, line in enumerate(baseconfig):
+            if key in str(line):
+                baseconfig[i] = key.encode() + b'=' + value.encode()
+                break
+
+    def unset_kernel_config(self, baseconfig, key):
+        for i, line in enumerate(baseconfig):
+            if line.startswith(key):
+                baseconfig[i] = b'# ' + key.encode() + b' is not set\n'
+                break
+
+    def patch_config(self, baseconfig, patch):
+        for line in patch:
+            if line.startswith("#"):
+                continue
+            vals = line.split("=", 1)
+            if len(vals) != 2:
+                continue
+            key = vals[0]
+            value = vals[1]
+            if value == "n":
+                self.unset_kernel_config(baseconfig, key)
+            else:
+                self.set_kernel_config(baseconfig, key, value)
+        return baseconfig
 
     def get_package_tree(self, version=''):
         self.list_repo()
@@ -27,17 +76,49 @@ class BottleRocketMirror(GitMirror):
         for v in bottlerocket_versions:
             bar = ProgressBar(label="Building config for bottlerocket v{}".format(v), length=1, file=sys.stderr)
             self.checkout_version(v)
-            # same meaning as the output of "uname -r"
             for kver in self.supported_kernel_releases:
+                # same meaning as the output of "uname -r"
                 kernel_release = self.extract_value(self.get_bottlerocket_kernel_spec(kver), "Version", ":")
-                kernel_version = "1_" + v
-                defconfig_base64 = self.encode_base64_defconfig(self.get_kernel_config_file_name())
-                kernel_configs[v + "_" + kver] = {
-                    self.KERNEL_VERSION: kernel_version,
-                    self.KERNEL_RELEASE: kernel_release,
-                    self.DISTRO_TARGET: "bottlerocket",
-                    self.BASE_64_CONFIG_DATA: defconfig_base64,
-                }
+                if kernel_release is None:
+                    continue
+
+                # Load base config
+                baseconfig = self.fetch_base_config(kver)
+                if baseconfig is None:
+                    continue
+
+                # Load common config
+                commonconfig_file = self.search_file(self.get_kernel_config_file_name())
+                if commonconfig_file is None:
+                    continue
+
+                with open(commonconfig_file, 'r') as fd:
+                    commonconfig = fd.readlines()
+
+                for flavor in self.supported_flavors:
+                    flavorconfig_file = self.search_file(self.get_kernel_config_file_name("-" + flavor))
+                    if flavorconfig_file is None:
+                        continue
+
+                    # Load flavor specific config
+                    with open(flavorconfig_file, 'r') as fd:
+                        flavorconfig = fd.readlines()
+
+                    # Merge flavor and common config
+                    flavorconfig += commonconfig
+
+                    # Finally, patch baseconfig with flavor config
+                    finalconfig = self.patch_config(baseconfig, flavorconfig)
+
+                    kernel_version = "1_" + v + "-" + flavor
+                    defconfig_base64 = base64.b64encode(b''.join(finalconfig)).decode()
+                    kernel_configs[v + "_" + kver] = {
+                        self.KERNEL_VERSION: kernel_version,
+                        self.KERNEL_RELEASE: kernel_release,
+                        self.DISTRO_TARGET: "bottlerocket",
+                        self.BASE_64_CONFIG_DATA: defconfig_base64,
+                    }
+
             bar.update(1)
             bar.render_finish()
 

--- a/kernel_crawler/bottlerocket.py
+++ b/kernel_crawler/bottlerocket.py
@@ -112,7 +112,8 @@ class BottleRocketMirror(GitMirror):
 
                     kernel_version = "1_" + v + "-" + flavor
                     defconfig_base64 = base64.b64encode(b''.join(finalconfig)).decode()
-                    kernel_configs[v + "_" + kver] = {
+                    # Unique key
+                    kernel_configs[v + "_" + kver + "-" + flavor] = {
                         self.KERNEL_VERSION: kernel_version,
                         self.KERNEL_RELEASE: kernel_release,
                         self.DISTRO_TARGET: "bottlerocket",

--- a/kernel_crawler/bottlerocket.py
+++ b/kernel_crawler/bottlerocket.py
@@ -1,0 +1,45 @@
+import shutil
+import sys
+
+from click import progressbar as ProgressBar
+
+from .git import GitMirror
+
+
+class BottleRocketMirror(GitMirror):
+    supported_kernel_releases = ["5.10", "5.15"]
+
+    def __init__(self, arch):
+        super(BottleRocketMirror, self).__init__("bottlerocket-os", "bottlerocket", arch)
+
+    def get_kernel_config_file_name(self):
+        return "config-bottlerocket"
+
+    def get_bottlerocket_kernel_spec(self, kver):
+        return "kernel-" + kver + ".spec"
+
+    def get_package_tree(self, version=''):
+        repo = self.list_repos()
+        sys.stdout.flush()
+        kernel_configs = {}
+        bottlerocket_versions = self.getVersions(repo, 3)
+
+        for v in bottlerocket_versions:
+            bar = ProgressBar(label="Building config for bottlerocket v{}".format(v), length=1, file=sys.stderr)
+            self.checkout_version(v, repo)
+            # same meaning as the output of "uname -r"
+            for kver in self.supported_kernel_releases:
+                kernel_release = self.extract_kernel_release(v, repo, self.get_bottlerocket_kernel_spec(kver))
+                kernel_version = "1_" + v
+                defconfig_base64 = self.encode_base64_defconfig(v, repo, self.get_kernel_config_file_name())
+                kernel_configs[v + "_" + kver] = {
+                    self.KERNEL_VERSION: kernel_version,
+                    self.KERNEL_RELEASE: kernel_release,
+                    self.DISTRO_TARGET: "bottlerocket",
+                    self.BASE_64_CONFIG_DATA: defconfig_base64,
+                }
+            bar.update(1)
+            bar.render_finish()
+
+        shutil.rmtree(repo.workdir, True)
+        return kernel_configs

--- a/kernel_crawler/crawler.py
+++ b/kernel_crawler/crawler.py
@@ -68,7 +68,7 @@ def to_driverkit_config(d, res):
 
     return dk_configs
 
-def crawl_kernels(distro, version, arch, images, to_driverkit):
+def crawl_kernels(distro, version, arch, images):
     ret = {}
 
     for distname, dist in DISTROS.items():
@@ -93,8 +93,5 @@ def crawl_kernels(distro, version, arch, images, to_driverkit):
                 res = d.get_package_tree(version)
 
             if d and res:
-                if to_driverkit:
-                    ret[distname] = to_driverkit_config(d, res)
-                else:
-                    ret[distname] = res
+                ret[distname] = to_driverkit_config(d, res)
     return ret

--- a/kernel_crawler/crawler.py
+++ b/kernel_crawler/crawler.py
@@ -19,6 +19,8 @@ from .redhat import RedhatContainer
 
 from .archlinux import ArchLinuxMirror
 
+from .bottlerocket import BottleRocketMirror
+
 DISTROS = {
     'AlmaLinux': AlmaLinuxMirror,
     'AmazonLinux': AmazonLinux1Mirror,
@@ -44,6 +46,8 @@ DISTROS = {
     'Redhat': RedhatContainer,
 
     'ArchLinux': ArchLinuxMirror,
+
+    'BottleRocket': BottleRocketMirror,
 }
 
 def to_driverkit_config(d, res):

--- a/kernel_crawler/git.py
+++ b/kernel_crawler/git.py
@@ -81,6 +81,17 @@ class GitMirror(Distro):
                     return os.path.join(dirpath, name)
         return None
 
+    def match_file(self, pattern, fullpath=True):
+        matches = []
+        for dirpath, dirnames, files in os.walk(self.repo.workdir):
+            for name in files:
+                if re.search(r'^'+pattern, name):
+                    if fullpath:
+                        matches.append(os.path.join(dirpath, name))
+                    else:
+                        matches.append(name)
+        return matches
+
     def extract_value(self, file_name, key, sep):
         # here kernel release is the same as the one given by "uname -r"
         full_path = self.search_file(file_name)

--- a/kernel_crawler/git.py
+++ b/kernel_crawler/git.py
@@ -39,6 +39,7 @@ class GitMirror(Distro):
 
     def __init__(self, repoorg, reponame, arch):
         mirrors = "https://github.com/"+repoorg+"/"+reponame+".git"
+        self.repo = None
         self.repo_name = reponame
         Distro.__init__(self, mirrors, arch)
 
@@ -46,29 +47,32 @@ class GitMirror(Distro):
         work_dir = tempfile.mkdtemp(prefix=self.repo_name + "-")
         return pygit2.clone_repository(repo_url, work_dir, callbacks=ProgressCallback(self.repo_name))
 
-    def list_repos(self):
-        return self.clone_repo(self.mirrors)
+    def list_repo(self):
+        self.repo = self.clone_repo(self.mirrors)
 
-    def getVersions(self, repo, lastN):
+    def cleanup_repo(self):
+        shutil.rmtree(self.repo.workdir, True)
+
+    def getVersions(self, last_n=0):
         re_tags = re.compile('^refs/tags/v(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)$')
 
-        all_versions = [os.path.basename(v).strip('v') for v in repo.references if re_tags.match(v)]
+        all_versions = [os.path.basename(v).strip('v') for v in self.repo.references if re_tags.match(v)]
         all_versions.sort(key=SemVersion)
 
         no_patch_versions = list(filter((lambda x: SemVersion(x).patch == 0), all_versions))
         no_patch_versions.sort(key=SemVersion)
 
         # We only get the lastN releases without considering the patch releases if requested
-        if lastN != -1:
-            no_patch_versions = no_patch_versions[-lastN:]
+        if last_n > 0:
+            no_patch_versions = no_patch_versions[-last_n:]
 
         # Here we are taking the three last releases plus the patch releases if they have any.
         # We are just taking all the releases(x.y.z) that are equal or greater than the older release we are considering,
         # i.e the older from the last three releases.
         return [v for v in all_versions if SemVersion(v) >= SemVersion(no_patch_versions[0])]
 
-    def checkout_version(self, vers, repo):
-        repo.checkout("refs/tags/v" + vers)
+    def checkout_version(self, vers):
+        self.repo.checkout("refs/tags/v" + vers)
 
     def search_files(self, directory, file_name):
         for dirpath, dirnames, files in os.walk(directory):
@@ -77,16 +81,16 @@ class GitMirror(Distro):
                     return os.path.join(dirpath, name)
         return None
 
-    def extract_kernel_release(self, vers, repo, file_name):
+    def extract_value(self, file_name, key, sep):
         # here kernel release is the same as the one given by "uname -r"
-        full_path = self.search_files(repo.workdir, file_name)
+        full_path = self.search_files(self.repo.workdir, file_name)
         for line in open(full_path):
-            if re.search(r'^Version:', line):
-                tokens = line.strip().split(':')
-                return tokens[1].strip()
+            if re.search(r'^'+key + sep, line):
+                tokens = line.strip().split(sep)
+                return tokens[1].strip('"').strip()
 
-    def encode_base64_defconfig(self, vers, repo, file_name):
-        full_path = self.search_files(repo.workdir, file_name)
+    def encode_base64_defconfig(self, file_name):
+        full_path = self.search_files(self.repo.workdir, file_name)
         with open(full_path, "rb") as config_file:
             return base64.b64encode(config_file.read()).decode()
 

--- a/kernel_crawler/git.py
+++ b/kernel_crawler/git.py
@@ -74,8 +74,8 @@ class GitMirror(Distro):
     def checkout_version(self, vers):
         self.repo.checkout("refs/tags/v" + vers)
 
-    def search_files(self, directory, file_name):
-        for dirpath, dirnames, files in os.walk(directory):
+    def search_file(self, file_name):
+        for dirpath, dirnames, files in os.walk(self.repo.workdir):
             for name in files:
                 if name == file_name:
                     return os.path.join(dirpath, name)
@@ -83,14 +83,17 @@ class GitMirror(Distro):
 
     def extract_value(self, file_name, key, sep):
         # here kernel release is the same as the one given by "uname -r"
-        full_path = self.search_files(self.repo.workdir, file_name)
+        full_path = self.search_file(file_name)
         for line in open(full_path):
             if re.search(r'^'+key + sep, line):
-                tokens = line.strip().split(sep)
+                tokens = line.strip().split(sep, 1)
                 return tokens[1].strip('"').strip()
+        return None
 
     def encode_base64_defconfig(self, file_name):
-        full_path = self.search_files(self.repo.workdir, file_name)
+        full_path = self.search_file(file_name)
+        if full_path is None:
+            return None
         with open(full_path, "rb") as config_file:
             return base64.b64encode(config_file.read()).decode()
 

--- a/kernel_crawler/git.py
+++ b/kernel_crawler/git.py
@@ -1,0 +1,99 @@
+import tempfile
+import shutil
+import re
+import os
+import base64
+import sys
+
+from click import progressbar as ProgressBar
+from semantic_version import Version as SemVersion
+import pygit2
+
+from kernel_crawler.repo import Distro, DriverKitConfig
+
+
+class ProgressCallback(pygit2.RemoteCallbacks):
+    def __init__(self, name):
+        self.progress_bar_initialized = False
+        self.bar = None
+        self.name = name
+        super().__init__()
+
+    def transfer_progress(self, stats):
+        if not self.progress_bar_initialized:
+            self.bar = ProgressBar(label='Cloning ' + self.name + ' repository', length=stats.total_objects, file=sys.stderr)
+            self.bar.update(1)
+            self.progress_bar_initialized = True
+        if not self.bar.is_hidden:
+            self.bar.update(1, stats.indexed_objects)
+        if stats.indexed_objects == stats.total_objects:
+            self.bar.render_finish()
+
+
+class GitMirror(Distro):
+    # dictionary keys used to build the kernel configuration dict.
+    KERNEL_VERSION = "kernelversion"
+    KERNEL_RELEASE = "kernelrelease"
+    DISTRO_TARGET = "target"
+    BASE_64_CONFIG_DATA = "kernelconfigdata"
+
+    def __init__(self, repoorg, reponame, arch):
+        mirrors = "https://github.com/"+repoorg+"/"+reponame+".git"
+        self.repo_name = reponame
+        Distro.__init__(self, mirrors, arch)
+
+    def clone_repo(self, repo_url):
+        work_dir = tempfile.mkdtemp(prefix=self.repo_name + "-")
+        return pygit2.clone_repository(repo_url, work_dir, callbacks=ProgressCallback(self.repo_name))
+
+    def list_repos(self):
+        return self.clone_repo(self.mirrors)
+
+    def getVersions(self, repo, lastN):
+        re_tags = re.compile('^refs/tags/v(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)$')
+
+        all_versions = [os.path.basename(v).strip('v') for v in repo.references if re_tags.match(v)]
+        all_versions.sort(key=SemVersion)
+
+        no_patch_versions = list(filter((lambda x: SemVersion(x).patch == 0), all_versions))
+        no_patch_versions.sort(key=SemVersion)
+
+        # We only get the lastN releases without considering the patch releases if requested
+        if lastN != -1:
+            no_patch_versions = no_patch_versions[-lastN:]
+
+        # Here we are taking the three last releases plus the patch releases if they have any.
+        # We are just taking all the releases(x.y.z) that are equal or greater than the older release we are considering,
+        # i.e the older from the last three releases.
+        return [v for v in all_versions if SemVersion(v) >= SemVersion(no_patch_versions[0])]
+
+    def checkout_version(self, vers, repo):
+        repo.checkout("refs/tags/v" + vers)
+
+    def search_files(self, directory, file_name):
+        for dirpath, dirnames, files in os.walk(directory):
+            for name in files:
+                if name == file_name:
+                    return os.path.join(dirpath, name)
+        return None
+
+    def extract_kernel_release(self, vers, repo, file_name):
+        # here kernel release is the same as the one given by "uname -r"
+        full_path = self.search_files(repo.workdir, file_name)
+        for line in open(full_path):
+            if re.search(r'^Version:', line):
+                tokens = line.strip().split(':')
+                return tokens[1].strip()
+
+    def encode_base64_defconfig(self, vers, repo, file_name):
+        full_path = self.search_files(repo.workdir, file_name)
+        with open(full_path, "rb") as config_file:
+            return base64.b64encode(config_file.read()).decode()
+
+    def to_driverkit_config(self, distro_release, config):
+        return DriverKitConfig(
+            config[self.KERNEL_RELEASE],
+            config[self.DISTRO_TARGET],
+            None,
+            config[self.KERNEL_VERSION],
+            config[self.BASE_64_CONFIG_DATA])

--- a/kernel_crawler/main.py
+++ b/kernel_crawler/main.py
@@ -21,12 +21,6 @@ def init_logging(debug):
 def cli(debug):
     init_logging(debug)
 
-class SetEncoder(json.JSONEncoder):
-    def default(self, obj):
-        if isinstance(obj, set):
-            return list(obj)
-        return json.JSONEncoder.default(self, obj)
-
 class DistroImageValidation(click.Option):
     def __init__(self, *args, **kwargs):
         self.required_if_distro:list = kwargs.pop("required_if_distro")
@@ -50,24 +44,11 @@ class DistroImageValidation(click.Option):
 @click.option('--distro', type=click.Choice(sorted(list(DISTROS.keys())) + ['*'], case_sensitive=True))
 @click.option('--version', required=False, default='')
 @click.option('--arch', required=False, type=click.Choice(['x86_64', 'aarch64'], case_sensitive=True), default='x86_64')
-@click.option('--out_fmt', required=False, type=click.Choice(['plain', 'json', 'driverkit'], case_sensitive=True),  default='plain')
 @click.option('--image', cls=DistroImageValidation, required_if_distro=["Redhat"], multiple=True)
-def crawl(distro, version='', arch='', out_fmt='', image=''):
-    res = crawl_kernels(distro, version, arch, image, out_fmt == 'driverkit')
-    out_fmt = str.lower(out_fmt)
-    if out_fmt == 'plain':
-        for dist, ks in res.items():
-            print('=== {} ==='.format(dist))
-            for release, packages in ks.items():
-                print('=== {} ==='.format(release))
-                for pkg in packages:
-                    print(' {}'.format(pkg))
-    elif out_fmt == 'json':
-        json_object = json.dumps(res, indent=2, cls=SetEncoder)
-        print(json_object)
-    elif out_fmt == 'driverkit':
-        json_object = json.dumps(res, indent=2, default=vars)
-        print(json_object)
+def crawl(distro, version='', arch='', image=''):
+    res = crawl_kernels(distro, version, arch, image)
+    json_object = json.dumps(res, indent=2, default=vars)
+    print(json_object)
 
 cli.add_command(crawl, 'crawl')
 

--- a/kernel_crawler/minikube.py
+++ b/kernel_crawler/minikube.py
@@ -1,4 +1,3 @@
-import shutil
 import sys
 
 from click import progressbar as ProgressBar

--- a/kernel_crawler/minikube.py
+++ b/kernel_crawler/minikube.py
@@ -1,93 +1,15 @@
-import tempfile
 import shutil
-import re
-import os
-import base64
 import sys
 
 from click import progressbar as ProgressBar
 from semantic_version import Version as SemVersion
-import pygit2
 
-from .repo import Distro, DriverKitConfig
+from .git import GitMirror
 
 
-class ProgressCallback(pygit2.RemoteCallbacks):
-    def __init__(self):
-        self.progress_bar_initialized = False
-        self.bar = None
-        super().__init__()
-    def transfer_progress(self, stats):
-        if not self.progress_bar_initialized:
-            self.bar = ProgressBar(label='Cloning minikube repository',length=stats.total_objects, file=sys.stderr)
-            self.bar.update(1)
-            self.progress_bar_initialized = True
-        if not self.bar.is_hidden:
-            self.bar.update(1, stats.indexed_objects)
-        if stats.indexed_objects == stats.total_objects:
-            self.bar.render_finish()
-
-class MinikubeMirror(Distro):
-    # dictionary keys used to build the kernel configuration dict.
-    KERNEL_VERSION = "kernelversion"
-    KERNEL_RELEASE = "kernelrelease"
-    DISTRO_TARGET = "target"
-    BASE_64_CONFIG_DATA = "kernelconfigdata"
-
+class MinikubeMirror(GitMirror):
     def __init__(self, arch):
-        mirrors = "https://github.com/kubernetes/minikube.git"
-        
-        Distro.__init__(self, mirrors, arch)
-    
-    def clone_repo(self, repo_url):
-        work_dir = tempfile.mkdtemp(prefix="minikube-")
-        return pygit2.clone_repository(repo_url, work_dir, callbacks=ProgressCallback())
-
-    def list_repos(self):
-        return self.clone_repo(self.mirrors)
-
-    def getVersions(self, repo):
-        re_tags = re.compile('^refs/tags/v(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)$')
-        
-        all_versions = [os.path.basename(v).strip('v') for v in repo.references if re_tags.match(v)]
-        all_versions.sort(key=SemVersion)
-
-        no_patch_versions = list(filter((lambda x: SemVersion(x).patch == 0), all_versions))
-        no_patch_versions.sort(key=SemVersion)
-        
-        # We only get the last three releases without considering the patch releases.
-        no_patch_versions = no_patch_versions[-3:]
-        # Here we are taking the three last releases plus the patch releases if they have any.
-        # We are just taking all the releases(x.y.z) that are equal or greater than the older release we are considering,
-        # i.e the older from the last three releases.
-        # For example, if the last three releases without considering the patches are : 1.24.0, 1.25.0 and 1.26.0 then
-        # we will consider the three release + all their patch releases.
-        return [v for v in all_versions if SemVersion(v) >= SemVersion(no_patch_versions[0])]
-
-    def checkout_version(self, minikube_version, repo):
-        repo.checkout("refs/tags/v" + minikube_version)
-
-    def search_files(self, directory, file_name):
-        for dirpath, dirnames, files in os.walk(directory):
-            for name in files :
-                if name == file_name:
-                    return os.path.join(dirpath, name)
-        return None
-    
-    def extract_kernel_release(self, minikube_version, repo):
-        # here kernel release is the same a the one given by "uname -r"
-        file_name = self.get_minikube_config_file_name(minikube_version)
-        full_path = self.search_files(repo.workdir, file_name)
-        for line in open(full_path):
-            if re.search(r'^BR2_LINUX_KERNEL_CUSTOM_VERSION_VALUE=', line):                
-                tokens = line.strip().split('=')
-                return tokens[1].strip('"')
-    
-    def encode_base64_defconfig(self, minikube_version, repo):
-        file_name = self.get_kernel_config_file_name(minikube_version)
-        full_path = self.search_files(repo.workdir, file_name)
-        with open(full_path, "rb") as config_file:
-            return base64.b64encode(config_file.read()).decode()
+        super(MinikubeMirror, self).__init__("kubernetes", "minikube", arch)
     
     def get_kernel_config_file_name(self, minikube_version):
         if SemVersion(minikube_version) >= SemVersion("1.26.0"):
@@ -103,7 +25,7 @@ class MinikubeMirror(Distro):
         repo = self.list_repos()
         sys.stdout.flush()
         kernel_configs = {}
-        minikube_versions = self.getVersions(repo)
+        minikube_versions = self.getVersions(repo, 3)
         
         for v in minikube_versions:
             bar = ProgressBar(label="Building config for minikube v{}".format(v), length=1, file=sys.stderr)
@@ -113,7 +35,7 @@ class MinikubeMirror(Distro):
                 continue
             self.checkout_version(v, repo)
             # same meaning as the output of "uname -r"
-            kernel_release = self.extract_kernel_release(v, repo)
+            kernel_release = self.extract_kernel_release(v, repo, self.get_minikube_config_file_name(v))
             # kernelversion is computed as "1_" + minikube version.
             # The reason behind that is due to how minikube distributes the iso images.
             # It could happen that two different minikube versions use the same kernel release but
@@ -121,7 +43,7 @@ class MinikubeMirror(Distro):
             # makes easier to get the right falco drivers from within a minikube instance.
             # same meaning as "uname -v"
             kernel_version = "1_" + v
-            defconfig_base64 = self.encode_base64_defconfig(v, repo)
+            defconfig_base64 = self.encode_base64_defconfig(v, repo, self.get_kernel_config_file_name(v))
             kernel_configs[v] = {
                 self.KERNEL_VERSION: kernel_version, 
                 self.KERNEL_RELEASE: kernel_release,
@@ -133,11 +55,3 @@ class MinikubeMirror(Distro):
         
         shutil.rmtree(repo.workdir, True)
         return kernel_configs
-
-    def to_driverkit_config(self, distro_release, config):
-        return DriverKitConfig(
-            config[self.KERNEL_RELEASE],
-            config[self.DISTRO_TARGET],
-            None,
-            config[self.KERNEL_VERSION],
-            config[self.BASE_64_CONFIG_DATA])

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setup(name='kernel-crawler',
           'docker',
           'semantic-version',
           'pygit2',
-          'beautifulsoup4'
+          'beautifulsoup4',
+          'rpmfile'
       ],
 )


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area crawler

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

The PR adds support for bottlerocket OS, following same git pattern of minikube.
Moreover, given that lots of code was shared between the 2 distros, a common `GitMirror` class has been added.

Finally, given that non-driverkit output was practically unsupported on both minikube and bottlerocket, i chose to drop support for non-driverkit outputs; we do not use them and moving forward, we will only support the driverkit-like json approach.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

