### PR TITLE
adding in some advanced centos community repos for ml kernels

### DIFF
--- a/kernel_crawler/centos.py
+++ b/kernel_crawler/centos.py
@@ -28,7 +28,12 @@ class CentosMirror(repo.Distro):
             rpm.RpmMirror('http://archive.kernel.org/centos/', 'BaseOS/' + arch + '/os/', v8_only),
             # It seems like centos stream uses /AppStream for kernel-devel, instead of BaseOS
             rpm.RpmMirror('http://mirror.stream.centos.org/', 'BaseOS/' + arch + '/os/', v9_only),
-            rpm.RpmMirror('http://mirror.stream.centos.org/', 'AppStream/' + arch + '/os/', v9_only)
+            rpm.RpmMirror('http://mirror.stream.centos.org/', 'AppStream/' + arch + '/os/', v9_only),
+            # These are some advanced mirrors for CentOS that enable newer kernels for ML
+            rpm.RpmMirror('http://elrepo.org/linux/kernel/', f'{arch}/'),
+            rpm.RpmMirror('http://mirrors.coreix.net/elrepo/kernel/', f'{arch}/'),
+            rpm.RpmMirror('http://mirror.rackspace.com/elrepo/kernel/', f'{arch}/'),
+            rpm.RpmMirror('http://linux-mirrors.fnal.gov/linux/elrepo/kernel/', f'{arch}/'),
         ]
         super(CentosMirror, self).__init__(mirrors, arch)
 

--- a/kernel_crawler/rpm.py
+++ b/kernel_crawler/rpm.py
@@ -42,7 +42,7 @@ class RpmRepository(repo.Repository):
 
     @classmethod
     def kernel_package_query(cls):
-        return '''name IN ('kernel', 'kernel-devel')'''
+        return '''name IN ('kernel', 'kernel-devel', 'kernel-ml', 'kernel-ml-devel')'''
 
     @classmethod
     def build_base_query(cls, filter=''):
@@ -113,14 +113,24 @@ class RpmMirror(repo.Mirror):
 
     def dist_exists(self, dist):
         try:
-            r = requests.get(self.dist_url(dist))
+            r = requests.get(
+                self.dist_url(dist),
+                headers={  # some URLs require a user-agent, otherwise they return HTTP 406 - this one is fabricated
+                    'user-agent': 'dummy'
+                }
+            )
             r.raise_for_status()
         except requests.exceptions.RequestException:
             return False
         return True
 
     def list_repos(self):
-        dists = requests.get(self.base_url)
+        dists = requests.get(
+            self.base_url, 
+            headers={  # some URLs require a user-agent, otherwise they return HTTP 406 - this one is fabricated
+                'user-agent': 'dummy'
+            }
+        )
         dists.raise_for_status()
         dists = dists.content
         doc = html.fromstring(dists, self.base_url)
@@ -155,7 +165,12 @@ class SUSERpmMirror(RpmMirror):
         '''
         Overridden from RpmMirror exchanging RpmRepository for SUSERpmRepository.
         '''
-        dists = requests.get(self.base_url)
+        dists = requests.get(
+            self.base_url,
+            headers={  # some URLs require a user-agent, otherwise they return HTTP 406 - this one is fabricated
+                'user-agent': 'dummy'
+            }
+        )
         dists.raise_for_status()
         dists = dists.content
         doc = html.fromstring(dists, self.base_url)

--- a/kernel_crawler/utils/download.py
+++ b/kernel_crawler/utils/download.py
@@ -7,7 +7,12 @@ except ImportError:
     from backports import lzma
 
 def get_url(url):
-    resp = requests.get(url)
+    resp = requests.get(
+        url,
+        headers={  # some URLs require a user-agent, otherwise they return HTTP 406 - this one is fabricated
+            'user-agent': 'dummy'
+        }
+    )
     resp.raise_for_status()
     if url.endswith('.gz'):
         return zlib.decompress(resp.content, 47)

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ docker
 semantic-version
 pygit2
 beautifulsoup4
+rpmfile


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note: it's really useful for the changelog!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind documentation

/kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area crawler

> /area ci

> /area utils

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

We had a request internally in our infrastructure to support some "advanced" kernels for CentOS 7 with driverkit. It took me a while to track down what mirrors they were using, but apparently there is a community hosting some crazy bleeding-edge kernels for CentOS that people use for ML and some advanced computing.

I'm trying to add those in here.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes # N/A

**Special notes for your reviewer**:

Here's an example of kernels added (commented out all the other mirrors and ran just these new ones):
```
{
  "CentOS": [
    {
      "kernelversion": 1,
      "kernelrelease": "6.2.7-1.el7.elrepo.x86_64",
      "target": "centos",
      "headers": [
        "http://elrepo.org/linux/kernel/el7/x86_64/RPMS/kernel-ml-devel-6.2.7-1.el7.elrepo.x86_64.rpm"
      ]
    },
    {
      "kernelversion": 1,
      "kernelrelease": "6.2.8-1.el7.elrepo.x86_64",
      "target": "centos",
      "headers": [
        "http://mirrors.coreix.net/elrepo/kernel/el7/x86_64/RPMS/kernel-ml-devel-6.2.8-1.el7.elrepo.x86_64.rpm"
      ]
    },
    {
      "kernelversion": 1,
      "kernelrelease": "6.2.7-1.el8.elrepo.x86_64",
      "target": "centos",
      "headers": [
        "http://mirror.rackspace.com/elrepo/kernel/el8/x86_64/RPMS/kernel-ml-devel-6.2.7-1.el8.elrepo.x86_64.rpm"
      ]
    },
    {
      "kernelversion": 1,
      "kernelrelease": "6.2.8-1.el8.elrepo.x86_64",
      "target": "centos",
      "headers": [
        "http://mirrors.coreix.net/elrepo/kernel/el8/x86_64/RPMS/kernel-ml-devel-6.2.8-1.el8.elrepo.x86_64.rpm"
      ]
    },
    {
      "kernelversion": 1,
      "kernelrelease": "6.2.7-1.el9.elrepo.x86_64",
      "target": "centos",
      "headers": [
        "http://elrepo.org/linux/kernel/el9/x86_64/RPMS/kernel-ml-devel-6.2.7-1.el9.elrepo.x86_64.rpm"
      ]
    },
    {
      "kernelversion": 1,
      "kernelrelease": "6.2.8-1.el9.elrepo.x86_64",
      "target": "centos",
      "headers": [
        "http://mirrors.coreix.net/elrepo/kernel/el9/x86_64/RPMS/kernel-ml-devel-6.2.8-1.el9.elrepo.x86_64.rpm"
      ]
    },
    {
      "kernelversion": 1,
      "kernelrelease": "6.2.6-1.el7.elrepo.x86_64",
      "target": "centos",
      "headers": [
        "http://mirror.rackspace.com/elrepo/kernel/el7/x86_64/RPMS/kernel-ml-devel-6.2.6-1.el7.elrepo.x86_64.rpm"
      ]
    },
    {
      "kernelversion": 1,
      "kernelrelease": "6.2.6-1.el8.elrepo.x86_64",
      "target": "centos",
      "headers": [
        "http://mirror.rackspace.com/elrepo/kernel/el8/x86_64/RPMS/kernel-ml-devel-6.2.6-1.el8.elrepo.x86_64.rpm"
      ]
    },
    {
      "kernelversion": 1,
      "kernelrelease": "6.2.6-1.el9.elrepo.x86_64",
      "target": "centos",
      "headers": [
        "http://mirror.rackspace.com/elrepo/kernel/el9/x86_64/RPMS/kernel-ml-devel-6.2.6-1.el9.elrepo.x86_64.rpm"
      ]
    }
  ]
}
```