### PR TITLE
update: oraclelinux9 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Crawl command:
 Usage: kernel-crawler crawl [OPTIONS]
 
 Options:
-    --distro [AmazonLinux|AmazonLinux2|AmazonLinux2022|BottleRocket|CentOS|Debian|Fedora|Flatcar|Minikube|Oracle6|Oracle7|Oracle8|PhotonOS|Redhat|Ubuntu|*]
+    --distro [AmazonLinux|AmazonLinux2|AmazonLinux2022|BottleRocket|CentOS|Debian|Fedora|Flatcar|Minikube|OracleLinux|PhotonOS|Redhat|Ubuntu|*]
     --version TEXT
     --arch [x86_64|aarch64]
     --image TEXT                    Option is required when distro is Redhat.

--- a/kernel_crawler/crawler.py
+++ b/kernel_crawler/crawler.py
@@ -4,7 +4,7 @@ from .almalinux import AlmaLinuxMirror
 from .amazonlinux import AmazonLinux1Mirror, AmazonLinux2Mirror, AmazonLinux2022Mirror
 from .centos import CentosMirror
 from .fedora import FedoraMirror
-from .oracle import Oracle6Mirror, Oracle7Mirror, Oracle8Mirror
+from .oracle import OracleMirror
 from .photon import PhotonOsMirror
 from .rockylinux import RockyLinuxMirror
 
@@ -28,9 +28,7 @@ DISTROS = {
     'AmazonLinux2022': AmazonLinux2022Mirror,
     'CentOS': CentosMirror,
     'Fedora': FedoraMirror,
-    'Oracle6': Oracle6Mirror,
-    'Oracle7': Oracle7Mirror,
-    'Oracle8': Oracle8Mirror,
+    'OracleLinux': OracleMirror,
     'PhotonOS': PhotonOsMirror,
     'RockyLinux': RockyLinuxMirror,
 

--- a/kernel_crawler/oracle.py
+++ b/kernel_crawler/oracle.py
@@ -1,65 +1,41 @@
 from . import repo
 from . import rpm
 
+
 class OracleRepository(rpm.RpmRepository):
     @classmethod
     def kernel_package_query(cls):
         return '''(name IN ('kernel', 'kernel-devel', 'kernel-uek', 'kernel-uek-devel') AND arch = 'x86_64')'''
 
 
-class Oracle6Mirror(repo.Distro):
+class OracleMirror(repo.Distro):
     def repos(self):
         return [
+            # Oracle6
             'http://yum.oracle.com/repo/OracleLinux/OL6/latest/' + self.arch + '/',
             'http://yum.oracle.com/repo/OracleLinux/OL6/MODRHCK/' + self.arch + '/',
             'http://yum.oracle.com/repo/OracleLinux/OL6/UEKR4/' + self.arch + '/',
             'http://yum.oracle.com/repo/OracleLinux/OL6/UEKR3/latest/' + self.arch + '/',
             'http://yum.oracle.com/repo/OracleLinux/OL6/UEK/latest/' + self.arch + '/',
-        ]
-
-    def __init__(self, arch):
-        super(Oracle6Mirror, self).__init__([], arch)
-
-    def list_repos(self):
-        return [OracleRepository(url) for url in self.repos()]
-
-    def to_driverkit_config(self, release, deps):
-        for dep in deps:
-            if dep.find("devel") != -1:
-                return repo.DriverKitConfig(release, "oracle6", dep)
-
-class Oracle7Mirror(repo.Distro):
-    def repos(self):
-        return [
+            # Oracle7
             'http://yum.oracle.com/repo/OracleLinux/OL7/latest/' + self.arch + '/',
             'http://yum.oracle.com/repo/OracleLinux/OL7/MODRHCK/' + self.arch + '/',
             'http://yum.oracle.com/repo/OracleLinux/OL7/UEKR6/' + self.arch + '/',
             'http://yum.oracle.com/repo/OracleLinux/OL7/UEKR5/' + self.arch + '/',
             'http://yum.oracle.com/repo/OracleLinux/OL7/UEKR4/' + self.arch + '/',
             'http://yum.oracle.com/repo/OracleLinux/OL7/UEKR3/' + self.arch + '/',
-        ]
-
-    def __init__(self, arch):
-        super(Oracle7Mirror, self).__init__([], arch)
-
-    def list_repos(self):
-        return [OracleRepository(url) for url in self.repos()]
-
-    def to_driverkit_config(self, release, deps):
-        for dep in deps:
-            if dep.find("devel") != -1:
-                return repo.DriverKitConfig(release, "oracle7", dep)
-
-
-class Oracle8Mirror(repo.Distro):
-    def repos(self):
-        return [
+            # Oracle8
             'http://yum.oracle.com/repo/OracleLinux/OL8/baseos/latest/' + self.arch + '/',
             'http://yum.oracle.com/repo/OracleLinux/OL8/UEKR6/' + self.arch + '/',
+            'http://yum.oracle.com/repo/OracleLinux/OL8/appstream/' + self.arch + '/',
+            # Oracle9
+            'http://yum.oracle.com/repo/OracleLinux/OL9/baseos/latest/' + self.arch + '/',
+            'http://yum.oracle.com/repo/OracleLinux/OL9/UEKR7/' + self.arch + '/',
+            'http://yum.oracle.com/repo/OracleLinux/OL9/appstream/' + self.arch + '/',
         ]
 
     def __init__(self, arch):
-        super(Oracle8Mirror, self).__init__([], arch)
+        super(OracleMirror, self).__init__([], arch)
 
     def list_repos(self):
         return [OracleRepository(url) for url in self.repos()]
@@ -67,4 +43,4 @@ class Oracle8Mirror(repo.Distro):
     def to_driverkit_config(self, release, deps):
         for dep in deps:
             if dep.find("devel") != -1:
-                return repo.DriverKitConfig(release, "oracle8", dep)
+                return repo.DriverKitConfig(release, "ol", dep)


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area crawler

**What this PR does / why we need it**:

Updated oracle to support OracleLinux9.
Moreover, unified OracleLinux{6,7,8,9} under single `OracleLinux`.
Finally, renamed output target to `ol`, that is the `ID` got from `/etc/os-release` on OracleLinux.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

