### PR TITLE
Reworking Oracle Possible URLs

### DIFF
--- a/kernel_crawler/oracle.py
+++ b/kernel_crawler/oracle.py
@@ -10,29 +10,41 @@ class OracleRepository(rpm.RpmRepository):
 
 class OracleMirror(repo.Distro):
     def repos(self):
-        return [
-            # Oracle6
-            'http://yum.oracle.com/repo/OracleLinux/OL6/latest/' + self.arch + '/',
-            'http://yum.oracle.com/repo/OracleLinux/OL6/MODRHCK/' + self.arch + '/',
-            'http://yum.oracle.com/repo/OracleLinux/OL6/UEKR4/' + self.arch + '/',
-            'http://yum.oracle.com/repo/OracleLinux/OL6/UEKR3/latest/' + self.arch + '/',
-            'http://yum.oracle.com/repo/OracleLinux/OL6/UEK/latest/' + self.arch + '/',
-            # Oracle7
-            'http://yum.oracle.com/repo/OracleLinux/OL7/latest/' + self.arch + '/',
-            'http://yum.oracle.com/repo/OracleLinux/OL7/MODRHCK/' + self.arch + '/',
-            'http://yum.oracle.com/repo/OracleLinux/OL7/UEKR6/' + self.arch + '/',
-            'http://yum.oracle.com/repo/OracleLinux/OL7/UEKR5/' + self.arch + '/',
-            'http://yum.oracle.com/repo/OracleLinux/OL7/UEKR4/' + self.arch + '/',
-            'http://yum.oracle.com/repo/OracleLinux/OL7/UEKR3/' + self.arch + '/',
-            # Oracle8
-            'http://yum.oracle.com/repo/OracleLinux/OL8/baseos/latest/' + self.arch + '/',
-            'http://yum.oracle.com/repo/OracleLinux/OL8/UEKR6/' + self.arch + '/',
-            'http://yum.oracle.com/repo/OracleLinux/OL8/appstream/' + self.arch + '/',
-            # Oracle9
-            'http://yum.oracle.com/repo/OracleLinux/OL9/baseos/latest/' + self.arch + '/',
-            'http://yum.oracle.com/repo/OracleLinux/OL9/UEKR7/' + self.arch + '/',
-            'http://yum.oracle.com/repo/OracleLinux/OL9/appstream/' + self.arch + '/',
+
+        # all the base URLs for major versions of OracleLinux
+        base_urls = [
+            # Oracle 6
+            'http://yum.oracle.com/repo/OracleLinux/OL6',  # Oracle 6
+            'http://yum.oracle.com/repo/OracleLinux/OL7',  # Oracle 7
+            'http://yum.oracle.com/repo/OracleLinux/OL8',  # Oracle 8
+            'http://yum.oracle.com/repo/OracleLinux/OL9',  # Oracle 9
         ]
+
+        # setup list for possible UEK URLs
+        possible_uek_urls = []
+        # Oracle seems to stick to 0 thru 9 for UEK versions, wrapping back to 0 after 9
+        possible_uek_versions = list(range(0, 10))
+        # loop through base URLs and possible UEK versions to build possible UEK URLs
+        for url in base_urls:
+            for uek_version in possible_uek_versions:
+                possible_uek_urls.append(f'{url}/UEKR{uek_version}/{self.arch}/')
+                possible_uek_urls.append(f'{url}/UEKR{uek_version}/latest/{self.arch}/')  # Oracle 6 has one URL subpath for /latest
+
+        # setup list for possible non UEK URLs
+        possible_non_uek_urls = []
+        # loop through base URLs and build other known URL subpaths
+        for url in base_urls:
+            possible_non_uek_urls.append(f'{url}/latest/{self.arch}/')         # Oracle 6 & 7
+            possible_non_uek_urls.append(f'{url}/MODRHCK/{self.arch}/')        # Oracle 6 & 7
+            possible_non_uek_urls.append(f'{url}/UEK/latest/{self.arch}/')     # Oracle 6 has this non-versioned UEK subpath
+            possible_non_uek_urls.append(f'{url}/baseos/latest/{self.arch}/')  # Oracle 8 & 9
+            possible_non_uek_urls.append(f'{url}/appstream/{self.arch}/')      # Oracle 8 & 9
+
+        # combine the built UEK URLs list and the base URLs
+        repos = [ repo for mirror in (possible_uek_urls, possible_non_uek_urls) for repo in mirror ]
+
+        return repos
+
 
     def __init__(self, arch):
         super(OracleMirror, self).__init__([], arch)

--- a/kernel_crawler/oracle.py
+++ b/kernel_crawler/oracle.py
@@ -9,11 +9,11 @@ class OracleRepository(rpm.RpmRepository):
 
 
 class OracleMirror(repo.Distro):
+
     def repos(self):
 
         # all the base URLs for major versions of OracleLinux
         base_urls = [
-            # Oracle 6
             'http://yum.oracle.com/repo/OracleLinux/OL6',  # Oracle 6
             'http://yum.oracle.com/repo/OracleLinux/OL7',  # Oracle 7
             'http://yum.oracle.com/repo/OracleLinux/OL8',  # Oracle 8

--- a/kernel_crawler/rpm.py
+++ b/kernel_crawler/rpm.py
@@ -75,6 +75,8 @@ class RpmRepository(repo.Repository):
 
     def get_repodb_url(self):
         repomd = get_url(self.base_url + 'repodata/repomd.xml')
+        if not repomd:
+            return None
         pkglist_url = self.get_loc_by_xpath(repomd, '//repo:repomd/repo:data[@type="primary_db"]/repo:location/@href')
         return self.base_url + pkglist_url
 
@@ -82,6 +84,8 @@ class RpmRepository(repo.Repository):
         packages = {}
         try:
             repodb_url = self.get_repodb_url()
+            if not repodb_url:
+                return {}
             repodb = get_url(repodb_url)
         except requests.exceptions.RequestException:
             traceback.print_exc()
@@ -204,6 +208,8 @@ class SUSERpmRepository(RpmRepository):
         SUSE stores their primary package listing under a different path in the XML from a normal RPM repomd.
         '''
         repomd = get_url(self.base_url + 'repodata/repomd.xml')
+        if not repomd:
+            return None
         pkglist_url = self.get_loc_by_xpath(repomd, '//repo:repomd/repo:data[@type="primary"]/repo:location/@href')
 
         # if no pkglist was found, return None
@@ -245,6 +251,8 @@ class SUSERpmRepository(RpmRepository):
         try:
             repodb_url = self.get_repodb_url()
             repodb = get_url(repodb_url)
+            if not repodb:
+                return {}
         except requests.exceptions.RequestException:
             # traceback.print_exc()  # extremely verbose, uncomment if debugging
             return {}

--- a/kernel_crawler/utils/download.py
+++ b/kernel_crawler/utils/download.py
@@ -1,6 +1,7 @@
 import bz2
 import zlib
 import requests
+
 try:
     import lzma
 except ImportError:
@@ -13,7 +14,14 @@ def get_url(url):
             'user-agent': 'dummy'
         }
     )
-    resp.raise_for_status()
+
+    # if 404, silently fail
+    if resp.status_code == 404:
+        return None
+    else:  # if any other error, raise the error - might be a bug in crawler
+        resp.raise_for_status()
+
+    # if no error, return the contents
     if url.endswith('.gz'):
         return zlib.decompress(resp.content, 47)
     elif url.endswith('.xz'):


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note: it's really useful for the changelog!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind documentation

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area crawler

> /area ci

> /area utils

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

It turns out we are missing some Oracle URLs, for example:
```[ol8_UEKR7]
name=Latest Unbreakable Enterprise Kernel Release 7 for Oracle Linux $releasever ($basearch)
baseurl=https://yum$ociregion.$ocidomain/repo/OracleLinux/OL8/UEKR7/$basearch/
gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-oracle
gpgcheck=1
enabled=1
```

After investigating Oracle's repos, it _looks_ like Oracle sticks to UEK versions of 0-9, looping back over to 0 after hitting 9...

So rather than hardcoding the UEK versions per Oracle major release, this approach just programmatically generates the possible URLs and chews through them. The 404s just get filtered out by the crawler naturally.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes # N/A

Related #75 though

**Special notes for your reviewer**:

Note, this does cause more churn/time spend, but does gain us a bit a future proofing (and more urls). By my estimates, previously we were crawling ~897 kernels for Oracle. With this change, we gain some future proofing, and are now at around 944 kernels:
```
╰─❯ jq -r '.OracleLinux[].kernelrelease' < oracle.json | wc -l
944
```

