### PR TITLE
Fix Fedora Crawls

### DIFF
--- a/kernel_crawler/rpm.py
+++ b/kernel_crawler/rpm.py
@@ -87,6 +87,8 @@ class RpmRepository(repo.Repository):
             if not repodb_url:
                 return {}
             repodb = get_url(repodb_url)
+            if not repodb:
+                return {}
         except requests.exceptions.RequestException:
             traceback.print_exc()
             return {}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note: it's really useful for the changelog!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind documentation

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area crawler

> /area ci

> /area utils

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

Found an issue where Fedora no longer crawls. Drilling into the issue... it seems the repo db comes back fine, but it points to a no longer existing archive. So when the crawler calls `get_url()` of that archive, it returns 404. In my previous update, I had handled 404's with a `return None`. I went through and handled all of these cases afterwards, but apparently missed one that Fedora trips.

No big deal. If the archive no longer exists, we just want to return no packages anyway. Small fix.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes # N/A

**Special notes for your reviewer**:

