### PR TITLE
new(ci): added ability to run the update-kernels gha for a single distro to choose from.

### DIFF
--- a/.github/workflows/update-kernels.yml
+++ b/.github/workflows/update-kernels.yml
@@ -3,12 +3,35 @@ name: Update Kernels
 
 on:
   workflow_dispatch:
+    inputs:
+      distro:
+        description: distro of which to perform the update
+        type: choice
+        required: false
+        options:
+          - '*'
+          - AmazonLinux
+          - AmazonLinux2
+          - AmazonLinux2022
+          - AmazonLinux2023
+          - BottleRocket
+          - CentOS
+          - Debian
+          - Fedora
+          - Flatcar
+          - Minikube
+          - OracleLinux
+          - PhotonOS
+          - Redhat
+          - Ubuntu
   schedule:
     - cron: '30 6 * * 1'
 
 jobs:
   update-kernels:
     runs-on: ubuntu-latest
+    env:
+      DISTRO: ${{ inputs.distro }}
     container:
       image: falcosecurity/kernel-crawler:latest
       options: -u root
@@ -21,13 +44,31 @@ jobs:
         with:
           ref: kernels
 
+      - name: Setup jq
+        run: apt-get update && apt-get install jq -y
+
       - name: Run crawler for x86_64
         run: |
-          kernel-crawler crawl --distro=* > x86_64/list.json
+          mkdir x86_64_tmp
+          kernel-crawler crawl --distro=${{ env.DISTRO }} > x86_64_tmp/list.json
 
       - name: Run crawler for aarch64
         run: |
-          kernel-crawler crawl --distro=* --arch=aarch64 > aarch64/list.json
+          mkdir aarch64_tmp
+          kernel-crawler crawl --distro=${{ env.DISTRO }} --arch=aarch64 > aarch64_tmp/list.json
+
+      - name: Single distro update
+        if: github.event_name == 'workflow_dispatch' && env.DISTRO != '*'
+        run: |
+          jq --arg distroKey "${{ env.DISTRO }}" --slurpfile newValues x86_64_tmp/list.json \
+          'if .[$distroKey] then .distroKey = $newValues else . end' x86_64_tmp/list.json > x86_64_tmp/output.json
+          jq --arg distroKey "${{ env.DISTRO }}" --slurpfile newValues aarch64_tmp/list.json \
+          'if .[$distroKey] then .distroKey = $newValues else . end' aarch64_tmp/list.json > aarch64_tmp/output.json
+
+      - name: Update json lists
+        run: |
+          cp x86_64_tmp/output.json x86_64/list.json
+          cp aarch64_tmp/output.json aarch64/list.json
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v5-rc

--- a/.github/workflows/update-kernels.yml
+++ b/.github/workflows/update-kernels.yml
@@ -66,11 +66,13 @@ jobs:
           --slurpfile newValues $RUNNER_TEMP/aarch64/list.json \
           'if .[$distroKey] then .distroKey = $newValues else . end' \
           aarch64/list.json > $RUNNER_TEMP/aarch64/output.json
+          mv $RUNNER_TEMP/x86_64/output.json $RUNNER_TEMP/x86_64/list.json
+          mv $RUNNER_TEMP/aarch64/output.json $RUNNER_TEMP/aarch64/list.json
 
       - name: Update json lists
         run: |
-          mv $RUNNER_TEMP/x86_64/output.json x86_64/list.json
-          mv $RUNNER_TEMP/aarch64/output.json aarch64/list.json
+          mv $RUNNER_TEMP/x86_64/list.json x86_64/list.json
+          mv $RUNNER_TEMP/aarch64/list.json aarch64/list.json
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v5-rc

--- a/.github/workflows/update-kernels.yml
+++ b/.github/workflows/update-kernels.yml
@@ -7,7 +7,7 @@ on:
       distro:
         description: distro of which to perform the update
         type: choice
-        required: false
+        required: true
         options:
           - '*'
           - AmazonLinux

--- a/.github/workflows/update-kernels.yml
+++ b/.github/workflows/update-kernels.yml
@@ -47,24 +47,28 @@ jobs:
 
       - name: Run crawler for x86_64
         run: |
+          INPUT_DISTRO=${{ inputs.distro }}
+          DISTRO=${INPUT_DISTRO:-'*''}
           mkdir $RUNNER_TEMP/x86_64
-          kernel-crawler crawl --distro=${{ inputs.distro }} > $RUNNER_TEMP/x86_64/list.json
+          kernel-crawler crawl --distro=$DISTRO > $RUNNER_TEMP/x86_64/list.json
 
       - name: Run crawler for aarch64
         run: |
+          INPUT_DISTRO=${{ inputs.distro }}
+          DISTRO=${INPUT_DISTRO:-'*''}
           mkdir $RUNNER_TEMP/aarch64
-          kernel-crawler crawl --distro=${{ inputs.distro }} --arch=aarch64 > $RUNNER_TEMP/aarch64/list.json
+          kernel-crawler crawl --distro=$DISTRO --arch=aarch64 > $RUNNER_TEMP/aarch64/list.json
 
       - name: Single distro update
         if: github.event_name == 'workflow_dispatch' && ${{ inputs.distro }} != '*'
         run: |
           jq --arg distroKey "${{ inputs.distro }}" \
           --slurpfile newValues $RUNNER_TEMP/x86_64/list.json \
-          'if .[$distroKey] then .distroKey = $newValues else . end' \
+          'if .[$distroKey] then .[$distroKey] = $newValues[][] else . end' \
           x86_64/list.json > $RUNNER_TEMP/x86_64/output.json
           jq --arg distroKey "${{ inputs.distro }}" \
           --slurpfile newValues $RUNNER_TEMP/aarch64/list.json \
-          'if .[$distroKey] then .distroKey = $newValues else . end' \
+          'if .[$distroKey] then .[$distroKey] = $newValues[][] else . end' \
           aarch64/list.json > $RUNNER_TEMP/aarch64/output.json
           mv $RUNNER_TEMP/x86_64/output.json $RUNNER_TEMP/x86_64/list.json
           mv $RUNNER_TEMP/aarch64/output.json $RUNNER_TEMP/aarch64/list.json

--- a/.github/workflows/update-kernels.yml
+++ b/.github/workflows/update-kernels.yml
@@ -30,8 +30,6 @@ on:
 jobs:
   update-kernels:
     runs-on: ubuntu-latest
-    env:
-      DISTRO: ${{ inputs.distro }}
     container:
       image: falcosecurity/kernel-crawler:latest
       options: -u root
@@ -49,26 +47,30 @@ jobs:
 
       - name: Run crawler for x86_64
         run: |
-          mkdir x86_64_tmp
-          kernel-crawler crawl --distro=${{ env.DISTRO }} > x86_64_tmp/list.json
+          mkdir $RUNNER_TEMP/x86_64
+          kernel-crawler crawl --distro=${{ inputs.distro }} > $RUNNER_TEMP/x86_64/list.json
 
       - name: Run crawler for aarch64
         run: |
-          mkdir aarch64_tmp
-          kernel-crawler crawl --distro=${{ env.DISTRO }} --arch=aarch64 > aarch64_tmp/list.json
+          mkdir $RUNNER_TEMP/aarch64
+          kernel-crawler crawl --distro=${{ inputs.distro }} --arch=aarch64 > $RUNNER_TEMP/aarch64/list.json
 
       - name: Single distro update
-        if: github.event_name == 'workflow_dispatch' && env.DISTRO != '*'
+        if: github.event_name == 'workflow_dispatch' && ${{ inputs.distro }} != '*'
         run: |
-          jq --arg distroKey "${{ env.DISTRO }}" --slurpfile newValues x86_64_tmp/list.json \
-          'if .[$distroKey] then .distroKey = $newValues else . end' x86_64_tmp/list.json > x86_64_tmp/output.json
-          jq --arg distroKey "${{ env.DISTRO }}" --slurpfile newValues aarch64_tmp/list.json \
-          'if .[$distroKey] then .distroKey = $newValues else . end' aarch64_tmp/list.json > aarch64_tmp/output.json
+          jq --arg distroKey "${{ inputs.distro }}" \
+          --slurpfile newValues $RUNNER_TEMP/x86_64/list.json \
+          'if .[$distroKey] then .distroKey = $newValues else . end' \
+          x86_64/list.json > $RUNNER_TEMP/x86_64/output.json
+          jq --arg distroKey "${{ inputs.distro }}" \
+          --slurpfile newValues $RUNNER_TEMP/aarch64/list.json \
+          'if .[$distroKey] then .distroKey = $newValues else . end' \
+          aarch64/list.json > $RUNNER_TEMP/aarch64/output.json
 
       - name: Update json lists
         run: |
-          cp x86_64_tmp/output.json x86_64/list.json
-          cp aarch64_tmp/output.json aarch64/list.json
+          mv $RUNNER_TEMP/x86_64/output.json x86_64/list.json
+          mv $RUNNER_TEMP/aarch64/output.json aarch64/list.json
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v5-rc


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note: it's really useful for the changelog!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

/kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

/area ci

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR introduces the possibility to run the [`update-kernels`](https://github.com/falcosecurity/kernel-crawler/blob/main/.github/workflows/update-kernels.yml) gha for a specific distro that can be selected when dispatching the job. This is useful to save time when we only want to crawl for a specific distro.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

`NONE`

**Special notes for your reviewer**:

`NONE`

