### PR TITLE
new(kernel_crawler): add talos support.

### DIFF
--- a/.github/workflows/update-kernels.yml
+++ b/.github/workflows/update-kernels.yml
@@ -23,6 +23,7 @@ on:
           - OracleLinux
           - PhotonOS
           - Redhat
+          - Talos
           - Ubuntu
   schedule:
     - cron: '30 6 * * 1'

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Crawl command:
 Usage: kernel-crawler crawl [OPTIONS]
 
 Options:
-    --distro [AmazonLinux|AmazonLinux2|AmazonLinux2022|AmazonLinux2023|BottleRocket|CentOS|Debian|Fedora|Flatcar|Minikube|OracleLinux|PhotonOS|Redhat|Ubuntu|*]
+    --distro [AmazonLinux|AmazonLinux2|AmazonLinux2022|AmazonLinux2023|BottleRocket|CentOS|Debian|Fedora|Flatcar|Minikube|OracleLinux|PhotonOS|Redhat|Talos|Ubuntu|*]
     --version TEXT
     --arch [x86_64|aarch64]
     --image TEXT                    Option is required when distro is Redhat.

--- a/kernel_crawler/crawler.py
+++ b/kernel_crawler/crawler.py
@@ -22,6 +22,8 @@ from .archlinux import ArchLinuxMirror
 
 from .bottlerocket import BottleRocketMirror
 
+from .talos import TalosMirror
+
 DISTROS = {
     'AliyunLinux': AliyunLinuxMirror,
     'AlmaLinux': AlmaLinuxMirror,
@@ -49,6 +51,8 @@ DISTROS = {
     'ArchLinux': ArchLinuxMirror,
 
     'BottleRocket': BottleRocketMirror,
+    
+    'Talos': TalosMirror,
 }
 
 def to_driverkit_config(d, res):

--- a/kernel_crawler/git.py
+++ b/kernel_crawler/git.py
@@ -96,8 +96,9 @@ class GitMirror(Distro):
         # here kernel release is the same as the one given by "uname -r"
         full_path = self.search_file(file_name)
         for line in open(full_path):
-            if re.search(r'^'+key + sep, line):
-                tokens = line.strip().split(sep, 1)
+            stripped_line = line.lstrip()
+            if re.search(r'^'+key + sep, stripped_line):
+                tokens = stripped_line.strip().split(sep, 1)
                 return tokens[1].strip('"').strip()
         return None
 

--- a/kernel_crawler/talos.py
+++ b/kernel_crawler/talos.py
@@ -1,0 +1,46 @@
+import sys
+
+from click import progressbar as ProgressBar
+from semantic_version import Version as SemVersion
+
+from .git import GitMirror
+
+from .debian import fixup_deb_arch
+
+class TalosMirror(GitMirror):
+    def __init__(self, arch):
+        super(TalosMirror, self).__init__("siderolabs", "pkgs", fixup_deb_arch(arch))
+
+    def get_package_tree(self, version=''):
+        self.list_repo()
+        sys.stdout.flush()
+        kernel_configs = {}
+        talos_versions = self.getVersions(3)
+        
+        for v in talos_versions:
+            bar = ProgressBar(label="Building config for talos v{}".format(v), length=1, file=sys.stderr)
+            self.checkout_version(v)
+            # same meaning as the output of "uname -r"
+            kernel_release = self.extract_value("Pkgfile", "linux_version", ":")
+            # Skip when we cannot load a kernel_release
+            if kernel_release is None:
+                continue
+            # kernelversion is computed as "1_" + talos version.
+            # The reason behind that is due to how talos distributes the iso images.
+            # It could happen that two different talos versions use the same kernel release but
+            # built with a different defconfig file. So having the talos version in the kernelversion
+            # makes easier to get the right falco drivers from within a talos instance.
+            # same meaning as "uname -v"
+            kernel_version = "1_" + v
+            defconfig_base64 = self.encode_base64_defconfig("config-" + self.arch)
+            kernel_configs[v] = {
+                self.KERNEL_VERSION: kernel_version, 
+                self.KERNEL_RELEASE: kernel_release,
+                self.DISTRO_TARGET: "talos",
+                self.BASE_64_CONFIG_DATA: defconfig_base64,
+                }
+            bar.update(1)
+            bar.render_finish()
+        
+        self.cleanup_repo()
+        return kernel_configs


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area crawler

**What this PR does / why we need it**:

This PR adds [talos](https://github.com/siderolabs/talos) kernels scraping for latest 3 releases, just like we do for minikube and bottlerocket.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

WIP because i first want to test that the kernelconfigdata we are fetching can correctly build a working driver.
