### PR TITLE
Oracle UEK's Use Kernel Version 2

### DIFF
--- a/kernel_crawler/oracle.py
+++ b/kernel_crawler/oracle.py
@@ -5,7 +5,7 @@ from . import rpm
 class OracleRepository(rpm.RpmRepository):
     @classmethod
     def kernel_package_query(cls):
-        return '''(name IN ('kernel', 'kernel-devel', 'kernel-uek', 'kernel-uek-devel') AND arch = 'x86_64')'''
+        return '''(name IN ('kernel', 'kernel-devel', 'kernel-uek', 'kernel-uek-devel'))'''
 
 
 class OracleMirror(repo.Distro):
@@ -55,4 +55,10 @@ class OracleMirror(repo.Distro):
     def to_driverkit_config(self, release, deps):
         for dep in deps:
             if dep.find("devel") != -1:
-                return repo.DriverKitConfig(release, "ol", dep)
+                if 'uek' in release:  # uek kernels have kernel versions of "2"
+                    # example:
+                    #  # uname -a
+                    #  Linux vm-ol8 5.15.0-100.96.32.el8uek.x86_64 #2 SMP Tue ...
+                    return repo.DriverKitConfig(release, "ol", dep, kernelversion=2)
+                else:  # else return default with kernelversion=1
+                    return repo.DriverKitConfig(release, "ol", dep)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note: it's really useful for the changelog!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind documentation

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area crawler

> /area ci

> /area utils

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

Something weird we've noticed... Several Oracle kernels report kernel version `#2` in `uname`. RPM-based distros typically ONLY report kernel version 1, but it seems Oracle is doing something outside the norm here. By default though, kernel-crawler always reports 1.

Here's an example of a version "2" kernel:
```
# uname -a
Linux vm-ol8 5.15.0-100.96.32.el8uek.x86_64 #2 SMP Tue Mar 28 18:08:15 PDT 2023 x86_64 x86_64 x86_64 GNU/Linux
```
Same system, installing a non-UEK kernel:
```
# uname -a
Linux vm-ol8 4.18.0-477.10.1.el8_8.x86_64 #1 SMP Tue May 16 11:07:48 PDT 2023 x86_64 x86_64 x86_64 GNU/Linux
```

Another example:
```
$ uname -a
Linux aws-ol8 5.15.0-101.103.2.1.el8uek.x86_64 #2 SMP Mon May 1 20:11:30 PDT 2023 x86_64 x86_64 x86_64 GNU/Linu
```

Another, this time Oracle 9:
```
$ uname -a
Linux aws-ol9 5.15.0-101.103.2.1.el9uek.x86_64 #2 SMP Tue May 2 01:10:45 PDT 2023 x86_64 x86_64 x86_64 GNU/Linux
```

...and a few more examples from online: 

- Oracle 7: https://forums.oracle.com/ords/apexds/post/enable-and-install-uek-release-6-on-oracle-linux-7-or-oracl-4279
- Oracle 8: https://blogs.oracle.com/scoter/post/uek-7-oracle-linux-8
- Oracle 6 even: https://forums.oracle.com/ords/apexds/post/oracle-linux-how-to-change-default-kernel-3742

As far as I can find though.. this is just an observation. I haven't been able to find any official documentation from Oracle supporting this. But all UEK's appear to report kernel version of 2.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes # N/A

**Special notes for your reviewer**:

As stated above, I'm unsure if we can find some official documentation or github reference that supports this... If anyone can find something, please let me know.

