### PR TITLE
fix(kernel_crawler): fixed talos output protocol.

### DIFF
--- a/kernel_crawler/talos.py
+++ b/kernel_crawler/talos.py
@@ -68,11 +68,11 @@ class TalosMirror(GitMirror):
             # built with a different defconfig file. So having the talos version in the kernelversion
             # makes easier to get the right falco drivers from within a talos instance.
             # same meaning as "uname -v"
-            kernel_version = "1_" + v
+            kernel_version = "1_v" + v
             defconfig_base64 = self.encode_base64_defconfig("config-" + self.arch)
             kernel_configs[v] = {
                 self.KERNEL_VERSION: kernel_version, 
-                self.KERNEL_RELEASE: kernel_release,
+                self.KERNEL_RELEASE: kernel_release + "-talos",
                 self.DISTRO_TARGET: "talos",
                 self.BASE_64_CONFIG_DATA: defconfig_base64,
                 }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area crawler

**What this PR does / why we need it**:

I missed some small quirks while implementing talos support.
* Falco-driver-loader looks for: `falco_talos_5.15.89-talos_1_v1.3.3.{ko,o}`
* kernel-crawler outputs: `falco_talos_5.15.89_1_1.3.3.{ko,o}`

Therefore, we need to:
* append `-talos` to the kernelrelease (their config has LOCALVERSION set to `-talos`: https://github.com/siderolabs/pkgs/blob/main/kernel/build/config-amd64#L31, that's why `uname -r` is returning it)
* prepend `v` to the talos version

New output example:
```
{
      "kernelversion": "1_v1.4.5",
      "kernelrelease": "6.1.30-talos",
      "target": "talos",
      "kernelconfigdata": "....."
}
```
That will match a `falco_talos_6.1.30-talos_1_v1.4.5` driver artifacts.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

