### PR TITLE
fix(ubuntu): removed version from kernel flavor

### DIFF
--- a/kernel_crawler/ubuntu.py
+++ b/kernel_crawler/ubuntu.py
@@ -28,6 +28,10 @@ class UbuntuMirror(repo.Distro):
                 # if capture was successful, set the flavor
                 if flavor_capture is not None:
                     flavor = flavor_capture.group(1)  # set flavor to the first capture group
+                    # in the case that the flavor results in aws-<version> we remove the version,
+                    # e.g.: aws-5.19 -> aws
+                    if '-' in flavor:
+                        flavor = flavor.split('-')[0]
 
                 target = f'ubuntu-{flavor}'    # expose the correct ubuntu flavor
                 release = f'{krel}-{flavor}'  # add flavor to release


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note: it's really useful for the changelog!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind documentation

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

/area crawler

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

This removes a **redundant** information in the output kernel `flavor`: instead of maintaining different "subflavors" (e.g. `aws-5.15`, `aws-5.19`, ...), we only keep one flavor (e.g. `aws`). At the end we'll end up with:

```
aws-5.19 -> aws
aws-5.15 -> aws
azure-5.15 -> azure
azure-5.19 -> azure
...
```

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

