### PR TITLE
fix(ci): properly quote distro when creating last_run_distro file.

### DIFF
--- a/.github/workflows/update-kernels.yml
+++ b/.github/workflows/update-kernels.yml
@@ -101,7 +101,7 @@ jobs:
 
       - name: Update last run distro
         run: |
-          echo ${{ env.distro }} > last_run_distro.txt
+          echo "${{ env.distro }}" > last_run_distro.txt
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v5-rc


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area ci

**What this PR does / why we need it**:

Fixes a stupid bug:
```
echo * > last_run_distro.txt
```
Would echo any filename present in the folder to last_run_distro.
We instead desired:
```
echo "*" > last_run_distro.txt
```

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

