### PR TITLE
fix(kernel_crawler): kernelversion should always be a string.

### DIFF
--- a/kernel_crawler/repo.py
+++ b/kernel_crawler/repo.py
@@ -12,7 +12,7 @@ class Repository(object):
         raise NotImplementedError
 
 class DriverKitConfig(object):
-    def __init__(self, kernelrelease, target, headers=None, kernelversion=1, kernelconfigdata=None):
+    def __init__(self, kernelrelease, target, headers=None, kernelversion="1", kernelconfigdata=None):
         self.kernelversion = kernelversion
         self.kernelrelease = kernelrelease
         self.target = target


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area crawler

**What this PR does / why we need it**:

Sometimes `kernelversion` is a string (when set). 
When left to its default value (ie: 1), it was previously set as integer, making it much harder to programmatically parse the output json.
Default to string value.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

