### PR TITLE
fix(kernel_crawler): enforce kernelversion to be a string.

### DIFF
--- a/kernel_crawler/flatcar.py
+++ b/kernel_crawler/flatcar.py
@@ -55,4 +55,4 @@ class FlatcarMirror(Distro):
         return repos
 
     def to_driverkit_config(self, release, deps):
-        return repo.DriverKitConfig(release, "flatcar", None, 1, list(deps)[0])
+        return repo.DriverKitConfig(release, "flatcar", None, "1", list(deps)[0])

--- a/kernel_crawler/oracle.py
+++ b/kernel_crawler/oracle.py
@@ -59,6 +59,6 @@ class OracleMirror(repo.Distro):
                     # example:
                     #  # uname -a
                     #  Linux vm-ol8 5.15.0-100.96.32.el8uek.x86_64 #2 SMP Tue ...
-                    return repo.DriverKitConfig(release, "ol", dep, kernelversion=2)
+                    return repo.DriverKitConfig(release, "ol", dep, kernelversion="2")
                 else:  # else return default with kernelversion=1
                     return repo.DriverKitConfig(release, "ol", dep)

--- a/kernel_crawler/repo.py
+++ b/kernel_crawler/repo.py
@@ -13,6 +13,8 @@ class Repository(object):
 
 class DriverKitConfig(object):
     def __init__(self, kernelrelease, target, headers=None, kernelversion="1", kernelconfigdata=None):
+        if not isinstance(kernelversion, str):
+            raise TypeError('kernelversion should be a string')
         self.kernelversion = kernelversion
         self.kernelrelease = kernelrelease
         self.target = target


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area crawler

**What this PR does / why we need it**:

Part 2 of #165 :D 
I forgot a couple of occurrences of int `kernelversion`.
Moreover, i also added a type check when building the `repo.DriverkitConfig` object.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

