### PR TITLE
cleanup(ci): drop workflow dispatch trigger.

### DIFF
--- a/.github/workflows/update-kernels.yml
+++ b/.github/workflows/update-kernels.yml
@@ -2,7 +2,6 @@
 name: Update Kernels
 
 on:
-  workflow_dispatch:
   schedule:
     - cron: '30 6 * * *'
 


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area ci

**What this PR does / why we need it**:

The `workflow_dispatch` trigger makes no sense now:
* we already run crawler daily
* even if we force a kernel-crawler run, test-infra `update-dbg` still runs daily, thus it has no effect at all

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

