### PR TITLE
fix(kernel_crawler): fix photonOS kernelrelease, stripping ".$arch" substring

### DIFF
--- a/kernel_crawler/photon.py
+++ b/kernel_crawler/photon.py
@@ -45,6 +45,12 @@ class PhotonOsMirror(repo.Distro):
             for version, repo_tag in self.PHOTON_OS_VERSIONS]
 
     def to_driverkit_config(self, release, deps):
+        # PhotonOS kernel packages have a ".$arch" suffix, 
+        # thus our kernelrelease is different from `uname -r` output.
+        # Fix this by manually removing the suffix.
+        suffix = "."+self.arch
+        if release.endswith(suffix):
+            release = release[:-len(suffix)]
         for dep in deps:
             if dep.find("-devel") != -1:
                 return repo.DriverKitConfig(release, "photon", dep)


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area crawler

**What this PR does / why we need it**:

PhotonOS kernel packages have a ".$arch" suffix, thus our kernelrelease is different from `uname -r` output.
Fix this by manually removing the suffix.
Example:
* `uname -r` -> `6.1.53-1.ph5`
* `kernelrelease` -> `6.1.53-1.ph5.x86_64`

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

