### PR TITLE
new(kernel_crawler): opensuse tumbleweed switched to zstd for its repodata

### DIFF
--- a/kernel_crawler/opensuse.py
+++ b/kernel_crawler/opensuse.py
@@ -30,8 +30,9 @@ class OpenSUSEMirror(repo.Distro):
             # the rest
             rpm.SUSERpmMirror('https://mirrors.edge.kernel.org/opensuse/distribution/', 'repo/oss/', arch),
             rpm.SUSERpmMirror('https://mirrors.edge.kernel.org/opensuse/distribution/', 'repo/oss/suse/', arch),
-            # opensuse site: tumbleweed
-            rpm.SUSERpmMirror('http://download.opensuse.org/', 'repo/oss/', arch, tumbleweed_filter),
+            # opensuse site: tumbleweed -> enforce zstd for repo:
+            # https://lists.opensuse.org/archives/list/factory@lists.opensuse.org/thread/LJNSBPCMIOJMP37PFPV7C7EJVIOW26BN/
+            rpm.SUSERpmMirror('http://download.opensuse.org/', 'repo/oss/', arch, tumbleweed_filter, True),
             # opensuse site: leaps
             rpm.SUSERpmMirror('http://download.opensuse.org/distribution/leap/', 'repo/oss/', arch),
             # opensuse Kernel repo - common

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ semantic-version
 pygit2
 beautifulsoup4
 rpmfile
+zstandard

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup(name='kernel-crawler',
           'semantic-version',
           'pygit2',
           'beautifulsoup4',
-          'rpmfile'
+          'rpmfile',
+          'zstandard'
       ],
 )


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area crawler

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

Title.
See https://lists.opensuse.org/archives/list/factory@lists.opensuse.org/thread/LJNSBPCMIOJMP37PFPV7C7EJVIOW26BN/ and our failing CI since a couple of days ;)

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

