### PR TITLE
chore(kernel_crawler): updated archlinux arm64 mirror.

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -35,11 +35,11 @@ runs:
       shell: bash
       working-directory: ${{ github.action_path }}
       run: |
-        kernel-crawler crawl --distro=${{ inputs.distro }} --arch=${{ inputs.arch }} > kernels_${{ inputs.arch }}.json
+        kernel-crawler crawl --distro=${{ inputs.distro }} --arch=${{ inputs.arch }} > ${{ runner.temp }}/kernels_${{ inputs.arch }}.json
 
     - name: Validate json
       shell: bash
-      working-directory: ${{ github.action_path }}
+      working-directory: ${{ runner.temp }}
       run: |
         cat kernels_${{ inputs.arch }}.json | jq empty
           
@@ -47,4 +47,4 @@ runs:
       id: store-outputs
       shell: bash
       run: |
-        echo "json=${{ github.action_path }}/kernels_${{ inputs.arch }}.json" >> $GITHUB_OUTPUT  
+        echo "json=${{ runner.temp }}/kernels_${{ inputs.arch }}.json" >> $GITHUB_OUTPUT

--- a/kernel_crawler/archlinux.py
+++ b/kernel_crawler/archlinux.py
@@ -68,12 +68,12 @@ class ArchLinuxMirror(repo.Distro):
             self._base_urls.append('https://archive.archlinux.org/packages/l/linux-lts-headers/')             # lts
             self._base_urls.append('https://archive.archlinux.org/packages/l/linux-zen-headers/')             # zen
         elif arch == 'aarch64':
-            self._base_urls.append('http://tardis.tiny-vps.com/aarm/packages/l/linux-aarch64-headers/')       # arm 64-bit
+            self._base_urls.append('https://alaa.ad24.cz/packages/l/linux-aarch64-headers/')       # arm 64-bit
         else:  # can be implemented later
-            self._base_urls.append('http://tardis.tiny-vps.com/aarm/packages/l/linux-armv5-headers/')         # arm v5
-            self._base_urls.append('http://tardis.tiny-vps.com/aarm/packages/l/linux-armv7-headers/')         # arm v7
-            self._base_urls.append('http://tardis.tiny-vps.com/aarm/packages/l/linux-raspberrypi4-headers/')  # rpi4
-            self._base_urls.append('http://tardis.tiny-vps.com/aarm/packages/l/linux-raspberrypi-headers/')   # other rpi
+            self._base_urls.append('https://alaa.ad24.cz/packages/l/linux-armv5-headers/')         # arm v5
+            self._base_urls.append('https://alaa.ad24.cz/packages/l/linux-armv7-headers/')         # arm v7
+            self._base_urls.append('https://alaa.ad24.cz/packages/l/linux-raspberrypi4-headers/')  # rpi4
+            self._base_urls.append('https://alaa.ad24.cz/packages/l/linux-raspberrypi-headers/')   # other rpi
 
         super(ArchLinuxMirror, self).__init__(self._base_urls, arch)
 


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area crawler

**What this PR does / why we need it**:

The old mirror is often down and it is not updated anymore (latest update 2022, kernel 5.19.8).

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

