### PR TITLE
chore(kernel_crawler): avoid failing if archlinux GET fails.

### DIFF
--- a/kernel_crawler/archlinux.py
+++ b/kernel_crawler/archlinux.py
@@ -10,7 +10,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+import requests
 from bs4 import BeautifulSoup
 import re
 
@@ -44,14 +44,17 @@ class ArchLinuxRepository(repo.Repository):
     def get_package_tree(self, filter=''):
         packages = {}
 
-        soup = BeautifulSoup(get_url(self.base_url), features='lxml')
-        for a in soup.find_all('a', href=True):
-            package = a['href']
-            # skip .sig and .. links
-            if not package.endswith('.sig') and package != '../':
-                parsed_kernel_release = self.parse_kernel_release(package)
+        try:
+            soup = BeautifulSoup(get_url(self.base_url), features='lxml')
+            for a in soup.find_all('a', href=True):
+                package = a['href']
+                # skip .sig and .. links
+                if not package.endswith('.sig') and package != '../':
+                    parsed_kernel_release = self.parse_kernel_release(package)
 
-                packages.setdefault(parsed_kernel_release, set()).add(self.base_url + package)
+                    packages.setdefault(parsed_kernel_release, set()).add(self.base_url + package)
+        except requests.HTTPError:
+            pass
 
         return packages
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area crawler

**What this PR does / why we need it**:

Since a couple of days, the newly added archlinux arm mirror (https://github.com/falcosecurity/kernel-crawler/pull/196) gives 500.
Skip instead of failing.
Hopefully the mirror will come back soon; i will double check in the next few days/weeks!

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

