### PR TITLE
new(kernel_crawler): implement automatic fallback to zstd for rpm repositories

### DIFF
--- a/kernel_crawler/opensuse.py
+++ b/kernel_crawler/opensuse.py
@@ -32,7 +32,7 @@ class OpenSUSEMirror(repo.Distro):
             rpm.SUSERpmMirror('https://mirrors.edge.kernel.org/opensuse/distribution/', 'repo/oss/suse/', arch),
             # opensuse site: tumbleweed -> enforce zstd for repo:
             # https://lists.opensuse.org/archives/list/factory@lists.opensuse.org/thread/LJNSBPCMIOJMP37PFPV7C7EJVIOW26BN/
-            rpm.SUSERpmMirror('http://download.opensuse.org/', 'repo/oss/', arch, tumbleweed_filter, True),
+            rpm.SUSERpmMirror('http://download.opensuse.org/', 'repo/oss/', arch, tumbleweed_filter),
             # opensuse site: leaps
             rpm.SUSERpmMirror('http://download.opensuse.org/distribution/leap/', 'repo/oss/', arch),
             # opensuse Kernel repo - common


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/kind feature


**Any specific area of the project related to this PR?**

/area crawler

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR fixes main CI: https://github.com/falcosecurity/kernel-crawler/actions/runs/10003733422/job/27651136552

Basically, opensuse switched some new repo to zstd. This PR automatically manages zstd as a fallback now.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

