### PR TITLE
fix(kernel_crawler): support fedora zstd compressed repodata.

### DIFF
--- a/kernel_crawler/utils/download.py
+++ b/kernel_crawler/utils/download.py
@@ -1,6 +1,8 @@
 import bz2
 import zlib
+import zstandard
 import requests
+import io
 
 try:
     import lzma
@@ -21,13 +23,16 @@ def get_url(url):
     else:  # if any other error, raise the error - might be a bug in crawler
         resp.raise_for_status()
 
-    # if no error, return the contents
+    # if no error, return the (eventually decompressed) contents
     if url.endswith('.gz'):
         return zlib.decompress(resp.content, 47)
     elif url.endswith('.xz'):
         return lzma.decompress(resp.content)
     elif url.endswith('.bz2'):
         return bz2.decompress(resp.content)
+    elif url.endswith('.zst'):
+        with zstandard.ZstdDecompressor().stream_reader(io.BytesIO(resp.content)) as rr:
+            return rr.read()
     else:
         return resp.content
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area crawler

**What this PR does / why we need it**:

Fedora createrepo_c script recently switched to use zstd compression by default for repodata; we need to support it otherwise running kernel-crawler will fail (and is already failing in CI).
Also, ported over openSuse ad-hoc zstd related solution to a more generic one that works for fedora too.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

