### PR TITLE
fix(kernel_crawler): remove amazon linux 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Crawl command:
 Usage: kernel-crawler crawl [OPTIONS]
 
 Options:
-    --distro [alinux|almalinux|amazonlinux|amazonlinux2|amazonlinux2022|amazonlinux2023|arch|bottlerocket|centos|debian|fedora|flatcar|minikube|ol|opensuse|photon|redhat|rocky|talos|ubuntu|*]
+    --distro [alinux|almalinux|amazonlinux2|amazonlinux2022|amazonlinux2023|arch|bottlerocket|centos|debian|fedora|flatcar|minikube|ol|opensuse|photon|redhat|rocky|talos|ubuntu|*]
     --version TEXT
     --arch [x86_64|aarch64]
     --image TEXT                    Option is required when distro is Redhat.

--- a/kernel_crawler/amazonlinux.py
+++ b/kernel_crawler/amazonlinux.py
@@ -29,35 +29,6 @@ def get_al_repo(repo_root, repo_release, repo_arch = ''):
     return make_string(resp.splitlines()[0]).replace('$basearch', repo_arch).rstrip('/') + '/'
 
 
-class AmazonLinux1Mirror(repo.Distro):
-    AL1_REPOS = [
-        'latest/updates',
-        'latest/main',
-        '2017.03/updates',
-        '2017.03/main',
-        '2017.09/updates',
-        '2017.09/main',
-        '2018.03/updates',
-        '2018.03/main',
-    ]
-
-    def __init__(self, arch):
-        super(AmazonLinux1Mirror, self).__init__([], arch)
-
-    def list_repos(self):
-        repo_urls = set()
-        with click.progressbar(
-                self.AL1_REPOS, label='Checking repositories', file=sys.stderr, item_show_func=repo.to_s) as repos:
-            for r in repos:
-                repo_urls.add(get_al_repo("http://repo.us-east-1.amazonaws.com/", r, self.arch))
-        return [rpm.RpmRepository(url) for url in sorted(repo_urls)]
-
-    def to_driverkit_config(self, release, deps):
-        for dep in deps:
-            if dep.find("devel") != -1:
-                return repo.DriverKitConfig(release, "amazonlinux", dep)
-
-
 class AmazonLinux2Mirror(repo.Distro):
     AL2_REPOS = [
         'core/2.0',

--- a/kernel_crawler/crawler.py
+++ b/kernel_crawler/crawler.py
@@ -15,7 +15,7 @@ from . import repo
 from .minikube import MinikubeMirror
 from .aliyunlinux import AliyunLinuxMirror
 from .almalinux import AlmaLinuxMirror
-from .amazonlinux import AmazonLinux1Mirror, AmazonLinux2Mirror, AmazonLinux2022Mirror, AmazonLinux2023Mirror
+from .amazonlinux import AmazonLinux2Mirror, AmazonLinux2022Mirror, AmazonLinux2023Mirror
 from .centos import CentosMirror
 from .fedora import FedoraMirror
 from .oracle import OracleMirror
@@ -42,7 +42,6 @@ from .talos import TalosMirror
 DISTROS = {
     'alinux': AliyunLinuxMirror,
     'almalinux': AlmaLinuxMirror,
-    'amazonlinux': AmazonLinux1Mirror,
     'amazonlinux2': AmazonLinux2Mirror,
     'amazonlinux2022': AmazonLinux2022Mirror,
     'amazonlinux2023': AmazonLinux2023Mirror,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note: it's really useful for the changelog!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

/kind cleanup

> /kind documentation

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area crawler

> /area ci

> /area utils

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

Currently the CI is broken as AWS blocked the previously scraped Amazon Linux 1 repository URLs. AL1 support ended on 2024/01/01 based on their documentation: https://docs.aws.amazon.com/batch/latest/userguide/al1-ami-deprecation.html

This removes all references for it from the crawler's codebase.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

