### PR TITLE
fix broken http mirror code

### DIFF
--- a/kernel_crawler/archlinux.py
+++ b/kernel_crawler/archlinux.py
@@ -70,13 +70,6 @@ class ArchLinuxMirror(repo.Distro):
             self._base_urls.append('https://archive.archlinux.org/packages/l/linux-hardened-headers/')        # hardened
             self._base_urls.append('https://archive.archlinux.org/packages/l/linux-lts-headers/')             # lts
             self._base_urls.append('https://archive.archlinux.org/packages/l/linux-zen-headers/')             # zen
-        elif arch == 'aarch64':
-            self._base_urls.append('https://alaa.ad24.cz/packages/l/linux-aarch64-headers/')       # arm 64-bit
-        else:  # can be implemented later
-            self._base_urls.append('https://alaa.ad24.cz/packages/l/linux-armv5-headers/')         # arm v5
-            self._base_urls.append('https://alaa.ad24.cz/packages/l/linux-armv7-headers/')         # arm v7
-            self._base_urls.append('https://alaa.ad24.cz/packages/l/linux-raspberrypi4-headers/')  # rpi4
-            self._base_urls.append('https://alaa.ad24.cz/packages/l/linux-raspberrypi-headers/')   # other rpi
 
         super(ArchLinuxMirror, self).__init__(self._base_urls, arch)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note: it's really useful for the changelog!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

/kind cleanup

> /kind documentation

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area crawler

> /area ci

> /area utils

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

The PR removes all ad24.cz URL, as it seems to be completely shut down. I'm not sure this is an acceptable fix, but I cannot find other mirror that would contain the same data.

~Second fix is in git.py as my locally built docket image complained about a not accessible attribute.~ it's broken in CI, commit dropped.

The code finished to run now for me completely.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

