### PR TITLE
Feature/add debian archive

### DIFF
--- a/kernel_crawler/debian.py
+++ b/kernel_crawler/debian.py
@@ -33,6 +33,9 @@ class DebianMirror(repo.Distro):
             deb.DebMirror('http://security.debian.org/', arch, repo_filter),
             deb.DebMirror('http://archive.raspberrypi.com/debian/', arch, repo_filter),
             deb.DebMirror('http://security.debian.org/debian-security/', arch, repo_filter),
+            deb.DebMirror('http://archive.debian.org/debian/', arch, repo_filter),
+           
+        
         ]
         super(DebianMirror, self).__init__(mirrors, arch)
 


### PR DESCRIPTION
## Description
This PR adds `http://archive.debian.org/debian/` to the `DebianMirror` list in `crawler/debian.py`.

## Motivation and Context
Currently, the crawler only looks at active mirrors. This means it fails to find kernel headers for older, End-of-Life (EOL) Debian releases because those packages are moved to the archive once they are no longer supported.

By adding the archive mirror, this change allows the crawler to discover and index these older kernels, ensuring `driverkit` can build drivers for legacy systems.

## Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)



